### PR TITLE
Improve role operations

### DIFF
--- a/packages/Acl/src/Models/Permissions/Group.php
+++ b/packages/Acl/src/Models/Permissions/Group.php
@@ -97,8 +97,7 @@ class Group extends Model implements Sluggable
         // a specific group. Since multiple permissions can be requested
         // created, we use database transactions for this method.
 
-        DB::beginTransaction();
-        try {
+        return DB::transaction(function () use ($slug, $permissions, $name, $description, $prefix) {
             // Find or create permissions group
             $group = static::findOrCreateBySlug($slug, [
                 'name' => $name ?? (string) Str::slugToWords($slug)->ucfirst(),
@@ -112,12 +111,8 @@ class Group extends Model implements Sluggable
             // Perform bulk insert
             static::make()->aclPermissionsModel()::insert($prepared);
 
-            DB::commit();
             return $group;
-        } catch (Throwable $e) {
-            DB::rollBack();
-            throw $e;
-        }
+        });
     }
 
     /*****************************************************************

--- a/packages/Acl/src/Models/Role.php
+++ b/packages/Acl/src/Models/Role.php
@@ -192,9 +192,11 @@ class Role extends Model implements Sluggable
             // grant all given permissions.
 
             /** @var static $role */
-            $role = static::create($attributes);
+            $role = static::create($attributes)
+                ->grantPermissions($permissions);
 
-            return $role->grantPermissions($permissions);
+            Db::commit();
+            return $role;
         } catch (Throwable $e) {
             DB::rollBack();
             throw $e;
@@ -262,10 +264,11 @@ class Role extends Model implements Sluggable
 
             if ($sync) {
                 $this->syncPermissions($permissions);
-                return $saved;
+            } else {
+                $this->grantPermissions($permissions);
             }
 
-            $this->grantPermissions($permissions);
+            Db::commit();
             return $saved;
         } catch (Throwable $e) {
             DB::rollBack();

--- a/packages/Acl/src/Models/Role.php
+++ b/packages/Acl/src/Models/Role.php
@@ -186,21 +186,11 @@ class Role extends Model implements Sluggable
      */
     public static function createWithPermissions(array $attributes, ...$permissions)
     {
-        DB::beginTransaction();
-        try {
-            // First, we create the role with given data and thereafter
-            // grant all given permissions.
-
+        return DB::transaction(function () use ($attributes, $permissions) {
             /** @var static $role */
-            $role = static::create($attributes)
-                ->grantPermissions($permissions);
-
-            Db::commit();
-            return $role;
-        } catch (Throwable $e) {
-            DB::rollBack();
-            throw $e;
-        }
+            return static::create($attributes)
+                    ->grantPermissions($permissions);
+        });
     }
 
     /**
@@ -253,11 +243,7 @@ class Role extends Model implements Sluggable
      */
     public function updateWithPermissions(array $attributes, bool $sync, ...$permissions): bool
     {
-        DB::beginTransaction();
-        try {
-            // Similar to the custom create method, we first update the role
-            // and thereafter either grant or sync the given permissions
-
+        return DB::transaction(function () use ($attributes, $sync, $permissions) {
             $saved = $this
                 ->fill($attributes)
                 ->save();
@@ -268,12 +254,8 @@ class Role extends Model implements Sluggable
                 $this->grantPermissions($permissions);
             }
 
-            Db::commit();
             return $saved;
-        } catch (Throwable $e) {
-            DB::rollBack();
-            throw $e;
-        }
+        });
     }
 
     /*****************************************************************

--- a/packages/Acl/src/Models/Role.php
+++ b/packages/Acl/src/Models/Role.php
@@ -202,6 +202,40 @@ class Role extends Model implements Sluggable
     }
 
     /**
+     * Update this role and grant given permissions
+     *
+     * @see updateWithPermissions
+     *
+     * @param array $attributes
+     * @param string|int|\Aedart\Acl\Models\Permission ...$permissions Permission slugs, ids or Permission instances
+     *
+     * @return bool
+     *
+     * @throws Throwable
+     */
+    public function updateAndGrantPermissions(array $attributes, ...$permissions): bool
+    {
+        return $this->updateWithPermissions($attributes, false, $permissions);
+    }
+
+    /**
+     * Update this role and sync given permissions
+     *
+     * @see updateWithPermissions
+     *
+     * @param array $attributes
+     * @param string|int|\Aedart\Acl\Models\Permission ...$permissions Permission slugs, ids or Permission instances
+     *
+     * @return bool
+     *
+     * @throws Throwable
+     */
+    public function updateAndSyncPermissions(array $attributes, ...$permissions): bool
+    {
+        return $this->updateWithPermissions($attributes, true, $permissions);
+    }
+
+    /**
      * Update this role, grant or sync the given permissions
      *
      * @see syncPermissions
@@ -215,7 +249,7 @@ class Role extends Model implements Sluggable
      *
      * @throws Throwable
      */
-    public function updateWithPermissions(array $attributes, bool $sync, ...$permissions)
+    public function updateWithPermissions(array $attributes, bool $sync, ...$permissions): bool
     {
         DB::beginTransaction();
         try {

--- a/tests/Integration/Acl/Models/RoleModelTest.php
+++ b/tests/Integration/Acl/Models/RoleModelTest.php
@@ -637,7 +637,7 @@ class RoleModelTest extends AclTestCase
             'name' => $faker->words(3, true),
         ];
 
-        $role->updateWithPermissions($data, false, $permissions);
+        $role->updateAndGrantPermissions($data, $permissions);
 
         // ---------------------------------------------------------------- //
         // Ensure role was updated and desired permissions have been granted
@@ -672,7 +672,7 @@ class RoleModelTest extends AclTestCase
             'name' => $faker->words(3, true),
         ];
 
-        $role->updateWithPermissions($data, true, $newPermissions);
+        $role->updateAndSyncPermissions($data, $newPermissions);
 
         // ---------------------------------------------------------------- //
         // Ensure role was updated and desired permissions have been granted
@@ -706,7 +706,7 @@ class RoleModelTest extends AclTestCase
             'name' => $faker->words(3, true),
         ];
 
-        $role->updateWithPermissions($data, true, []);
+        $role->updateAndSyncPermissions($data, []);
 
         // ---------------------------------------------------------------- //
         // Ensure role was updated and desired permissions have been granted

--- a/tests/Integration/Acl/Models/RoleModelTest.php
+++ b/tests/Integration/Acl/Models/RoleModelTest.php
@@ -2,6 +2,7 @@
 
 namespace Aedart\Tests\Integration\Acl\Models;
 
+use Aedart\Acl\Models\Role;
 use Aedart\Testing\Helpers\ConsoleDebugger;
 use Aedart\Tests\TestCases\Acl\AclTestCase;
 
@@ -590,5 +591,128 @@ class RoleModelTest extends AclTestCase
 
         $table = $this->aclTable('roles_permissions');
         $this->assertDatabaseCount($table, 0, 'testing');
+    }
+
+    /**
+     * @test
+     *
+     * @throws \Throwable
+     */
+    public function canCreateRoleWithPermissions()
+    {
+        $group = $this->createPermissionGroupWithPermissions('users');
+        $permissions = $group->permissions->take(3);
+
+        $faker = $this->getFaker();
+        $data = [
+            'slug' => $faker->unique()->slug,
+            'name' => $faker->words(3, true),
+            'description' => $faker->words(20, true)
+        ];
+
+        $role = Role::createWithPermissions($data, $permissions);
+
+        // ---------------------------------------------------------------- //
+        // Ensure role was created and desired permissions have been granted
+
+        $this->assertNotNull($role, 'Role was not created!');
+        $this->assertSame($data['slug'], $role->slug, 'Incorrect attributes appear to have been used!?');
+
+        $this->assertTrue($role->hasAllPermissions($permissions), 'Permissions do not appear to have been granted');
+    }
+
+    /**
+     * @test
+     *
+     * @throws \Throwable
+     */
+    public function canUpdateRoleWithPermissions()
+    {
+        $group = $this->createPermissionGroupWithPermissions('users');
+        $permissions = $group->permissions->take(2);
+        $role = $this->createRole();
+
+        $faker = $this->getFaker();
+        $data = [
+            'name' => $faker->words(3, true),
+        ];
+
+        $role->updateWithPermissions($data, false, $permissions);
+
+        // ---------------------------------------------------------------- //
+        // Ensure role was updated and desired permissions have been granted
+
+        $this->assertSame($data['name'], $role->name, 'Incorrect attributes appear to have been used!?');
+
+        $this->assertTrue($role->hasAllPermissions($permissions), 'Permissions do not appear to have been granted');
+    }
+
+    /**
+     * @test
+     *
+     * @throws \Throwable
+     */
+    public function canUpdateRoleAndSyncPermissions()
+    {
+        $group = $this->createPermissionGroupWithPermissions('users');
+        $permissions = $group->permissions;
+        $role = $this->createRole();
+
+        // ---------------------------------------------------------------- //
+        // Initially, we grant a few permissions
+        $role->grantPermissions($permissions);
+
+        // ---------------------------------------------------------------- //
+        // Update and sync with new Permissions
+
+        $newPermissions = $this->createPermissionGroupWithPermissions('products')->permissions;
+
+        $faker = $this->getFaker();
+        $data = [
+            'name' => $faker->words(3, true),
+        ];
+
+        $role->updateWithPermissions($data, true, $newPermissions);
+
+        // ---------------------------------------------------------------- //
+        // Ensure role was updated and desired permissions have been granted
+
+        $this->assertSame($data['name'], $role->name, 'Incorrect attributes appear to have been used!?');
+
+        $this->assertTrue($role->hasAllPermissions($newPermissions), 'New permissions NOT synced');
+        $this->assertFalse($role->hasAllPermissions($permissions), 'Old permissions NOT revoked');
+    }
+
+    /**
+     * @test
+     *
+     * @throws \Throwable
+     */
+    public function revokesAllPermissionsWhenSyncUpdating()
+    {
+        $group = $this->createPermissionGroupWithPermissions('users');
+        $permissions = $group->permissions;
+        $role = $this->createRole();
+
+        // ---------------------------------------------------------------- //
+        // Initially, we grant a few permissions
+        $role->grantPermissions($permissions);
+
+        // ---------------------------------------------------------------- //
+        // Update and sync with no permissions
+
+        $faker = $this->getFaker();
+        $data = [
+            'name' => $faker->words(3, true),
+        ];
+
+        $role->updateWithPermissions($data, true, []);
+
+        // ---------------------------------------------------------------- //
+        // Ensure role was updated and desired permissions have been granted
+
+        $this->assertSame($data['name'], $role->name, 'Incorrect attributes appear to have been used!?');
+
+        $this->assertFalse($role->hasAllPermissions($permissions), 'Old permissions NOT revoked');
     }
 }


### PR DESCRIPTION
PR adds `createWithPermissions()` and `updateWithPermissions()` helper methods to the ACL Role Eloquent model.