### PR TITLE
Fix array to string conversion, in Arr::differenceAssoc

### DIFF
--- a/packages/Utils/src/Arr.php
+++ b/packages/Utils/src/Arr.php
@@ -70,12 +70,39 @@ class Arr extends ArrBase
             throw new InvalidArgumentException('You need at least 2 arrays for computing difference');
         }
 
-        $array = static::dot($array);
+        $array = static::clearNestedEmptyArrays(
+            static::dot($array)
+        );
 
-        $arrays = array_map(function ($item) {
-            return static::dot($item);
+        $arrays = array_map(function ($array) {
+            return static::clearNestedEmptyArrays(
+                static::dot($array)
+            );
         }, $arrays);
 
         return static::undot(array_diff_assoc($array, ...$arrays));
+    }
+
+    /**
+     * Replaces nested empty array values
+     *
+     * @param array $array
+     * @param mixed $replaceValue [optional] Value to replace empty arrays with
+     *
+     * @return array
+     */
+    protected static function clearNestedEmptyArrays(array $array, $replaceValue = null): array
+    {
+        $output = [];
+
+        foreach ($array as $key => $value) {
+            if (is_array($value) && empty($value)) {
+                $value = $replaceValue;
+            }
+
+            $output[$key] = $value;
+        }
+
+        return $output;
     }
 }

--- a/tests/Unit/Utils/ArrTest.php
+++ b/tests/Unit/Utils/ArrTest.php
@@ -119,4 +119,46 @@ class ArrTest extends UnitTestCase
         $this->assertArrayHasKey('required', $validation);
         $this->assertArrayHasKey('max', $validation);
     }
+
+    /**
+     * @test
+     */
+    public function doesNotFailDiffOfAssocWhenEmptyNestedArrays()
+    {
+        $original = [
+            'key' => 'person',
+            'value' => 'John Snow',
+            'settings' => []
+        ];
+
+        $changed = [
+            'key' => 'person',
+            'value' => 'Jack Snow', // Changed
+            'settings' => [] // Can cause array to string conversion!, using php's array_diff_assoc
+        ];
+
+        $result = Arr::differenceAssoc($changed, $original);
+        ConsoleDebugger::output($result);
+
+        $this->assertArrayHasKey('value', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function doesNotFailDiffOfAssocWhenEmptyNullValues()
+    {
+        $original = [
+            'key' => null,
+        ];
+
+        $changed = [
+            'key' => null,
+        ];
+
+        $result = Arr::differenceAssoc($changed, $original);
+        ConsoleDebugger::output($result);
+
+        $this->assertEmpty($result);
+    }
 }


### PR DESCRIPTION
This fixes #47. Solution has become slightly more heavy, but the functionality now works as expected. 