### PR TITLE
Fix call to parse query

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": ">=7.4.0",
         "dragonmantank/cron-expression": "^3.0",
         "fzaninotto/faker": "1.9.*",
-        "guzzlehttp/guzzle": "^7.1",
+        "guzzlehttp/guzzle": "^7.3",
         "illuminate/auth": "^8.15",
         "illuminate/cache": "^8.15",
         "illuminate/collections": "^8.15",

--- a/packages/Http/Clients/composer.json
+++ b/packages/Http/Clients/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": ">=7.4.0",
-        "guzzlehttp/guzzle": "^7.1",
+        "guzzlehttp/guzzle": "^7.3",
         "psr/http-message": "^1.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",

--- a/tests/Integration/Http/Clients/C1_QueryTest.php
+++ b/tests/Integration/Http/Clients/C1_QueryTest.php
@@ -5,9 +5,8 @@ namespace Aedart\Tests\Integration\Http\Clients;
 use Aedart\Contracts\Http\Clients\Exceptions\ProfileNotFoundException;
 use Aedart\Testing\Helpers\ConsoleDebugger;
 use Aedart\Tests\TestCases\Http\HttpClientsTestCase;
+use GuzzleHttp\Psr7\Query;
 use Psr\Http\Message\ResponseInterface;
-
-use function GuzzleHttp\Psr7\parse_query;
 
 /**
  * C1_QueryTest
@@ -98,7 +97,7 @@ class C1_QueryTest extends HttpClientsTestCase
         // --------------------------------------------------- //
 
         $sentQuery = $this->lastRequest->getUri()->getQuery();
-        $sentQuery = parse_query($sentQuery);
+        $sentQuery = Query::parse($sentQuery);
 
         ConsoleDebugger::output($sentQuery);
 


### PR DESCRIPTION
Apparently Guzzle removed several of it's utility helper methods and replaced it with class components. the previous `GuzzleHttp\Psr7\parse_query()` has been replaced with `\GuzzleHttp\Psr7\Query::parse()`.

This appears to have changed in the following [PR](https://github.com/guzzle/guzzle/pull/2712).

In any case, the utility was only used internally for a few tests and not for by the actual package implementation. Thus, this isn't anything serious or breaking. This fixes #49 