### PR TITLE
Add a way to automatically paginate through available results

### DIFF
--- a/packages/Contracts/src/Redmine/Iterators/ResultsIterator.php
+++ b/packages/Contracts/src/Redmine/Iterators/ResultsIterator.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Aedart\Contracts\Redmine\Iterators;
+
+use Aedart\Contracts\Http\Clients\Requests\Builder;
+use Aedart\Contracts\Redmine\ApiResource;
+use Countable;
+use Iterator;
+
+/**
+ * Results Iterator
+ *
+ * @author Alin Eugen Deac <ade@rspsystems.com>
+ * @package Aedart\Contracts\Redmine\Iterators
+ */
+interface ResultsIterator extends Iterator,
+    Countable
+{
+    /**
+     * The API Resource in question
+     *
+     * @return ApiResource
+     */
+    public function resource(): ApiResource;
+
+    /**
+     * The request builder used by this iterator
+     *
+     * @return Builder
+     */
+    public function request(): Builder;
+}

--- a/packages/Contracts/src/Redmine/TraversableResults.php
+++ b/packages/Contracts/src/Redmine/TraversableResults.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Aedart\Contracts\Redmine;
+
+use Countable;
+use IteratorAggregate;
+
+/**
+ * Traversable Results
+ *
+ * @author Alin Eugen Deac <ade@rspsystems.com>
+ * @package Aedart\Contracts\Redmine
+ */
+interface TraversableResults extends IteratorAggregate,
+    Countable
+{
+}

--- a/packages/Redmine/src/Pagination/Iterators/ResultsIterator.php
+++ b/packages/Redmine/src/Pagination/Iterators/ResultsIterator.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace Aedart\Redmine\Pagination\Iterators;
+
+use Aedart\Contracts\Http\Clients\Requests\Builder;
+use Aedart\Contracts\Redmine\ApiResource;
+use Aedart\Contracts\Redmine\Exceptions\UnsupportedOperationException;
+use Aedart\Contracts\Redmine\Iterators\ResultsIterator as ResultsIteratorInterface;
+use Aedart\Contracts\Redmine\PaginatedResults;
+use JsonException;
+use Throwable;
+
+/**
+ * Results Iterator
+ *
+ * @author Alin Eugen Deac <ade@rspsystems.com>
+ * @package Aedart\Redmine\Pagination\Iterators
+ */
+class ResultsIterator implements ResultsIteratorInterface
+{
+    /**
+     * The API Resource that must perform pagination
+     *
+     * @var ApiResource
+     */
+    protected ApiResource $resource;
+
+    /**
+     * The request builder
+     *
+     * @var Builder
+     */
+    protected Builder $request;
+
+    /**
+     * The "pool" size - maximum limit of results to fetch
+     * per request
+     *
+     * @var int
+     */
+    protected int $size;
+
+    /**
+     * The current results set
+     *
+     * @var PaginatedResults
+     */
+    protected PaginatedResults $resultsSet;
+
+    /**
+     * Current iterator position, in current results set
+     *
+     * @var int
+     */
+    protected int $relativePosition = 0;
+
+    /**
+     * The absolute position if the iterator, across
+     * all available results
+     *
+     * @var int
+     */
+    protected int $absolutePosition = 0;
+
+    /**
+     * ResultsIterator
+     *
+     * @param ApiResource $resource
+     * @param Builder $request
+     * @param int $size [optional] The "pool" size - maximum limit of results to fetch per request
+     */
+    public function __construct(ApiResource $resource, Builder $request, int $size = 10)
+    {
+        $this->resource = $resource;
+        $this->request = $request;
+        $this->size = $size;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function current()
+    {
+        $this->rewindIfRequired();
+
+        // Return from current results set
+        return $this->resultsSet
+            ->results()
+            ->get($this->relativePosition);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function next()
+    {
+        $resultsSet = $this->resultsSet;
+
+        // Compute next relative position...
+        $nextRelativePosition = $this->relativePosition + 1;
+
+        // When the next relative position does not exist, yet there are more results to be
+        // fetched, perform the next request.
+        if (!$resultsSet->results()->has($nextRelativePosition) && $resultsSet->hasNextPage()) {
+            // Paginate to next results - relative position will be reset to zero!
+            $this->paginate($resultsSet->nextPageOffset());
+
+            // Increase the absolute position
+            $this->absolutePosition++;
+
+            // Stop further processing
+            return;
+        }
+
+        // Increase the relative position - even if this might cause in null to be
+        // returned by the current() method - can happen if next is invoked several
+        // times, long after there are no more results. Such would be a violation
+        // of the iterator capabilities, yet the interface does not state that
+        // it's an illegal act.
+        $this->relativePosition = $nextRelativePosition;
+
+        // Lastly, we also increase the absolute position - even if this will cause
+        // an invalid position. The valid method must ensure to check for this.
+        $this->absolutePosition++;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function key()
+    {
+        return $this->absolutePosition;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function valid()
+    {
+        $this->rewindIfRequired();
+
+        return $this->absolutePosition < $this->resultsSet->total();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function rewind()
+    {
+        // Skip rewind, if we already are at the first results set.
+        if (isset($this->resultsSet) && $this->resultsSet->currentPage() === $this->resultsSet->firstPage()) {
+            return;
+        }
+
+        // Fetch results for the first page
+        $this->paginate(0);
+
+        // Reset the absolute position
+        $this->absolutePosition = 0;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function count()
+    {
+        $this->rewindIfRequired();
+
+        return $this->resultsSet->total();
+    }
+
+    /**
+     * The API Resource in question
+     *
+     * @return ApiResource
+     */
+    public function resource(): ApiResource
+    {
+        return $this->resource;
+    }
+
+    /**
+     * The request builder used by this iterator
+     *
+     * @return Builder
+     */
+    public function request(): Builder
+    {
+        return $this->request;
+    }
+
+    /*****************************************************************
+     * Internals
+     ****************************************************************/
+
+    /**
+     * Rewind - fetch first results, but only if no previous results
+     * have been obtained.
+     *
+     * @return self
+     */
+    protected function rewindIfRequired(): self
+    {
+        if (!isset($this->resultsSet)) {
+            $this->rewind();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Fetch results at given offset
+     *
+     * @param int $offset [optional]
+     *
+     * @throws UnsupportedOperationException
+     * @throws JsonException
+     * @throws Throwable
+     */
+    protected function paginate(int $offset = 0)
+    {
+        // Fetch "new" results
+        $this->resultsSet = $this
+            ->resource()
+            ->paginate(
+                $this->request(),
+                $this->size,
+                $offset
+            );
+
+        // Reset the relative position
+        $this->relativePosition = 0;
+    }
+}

--- a/packages/Redmine/src/Pagination/TraversableResults.php
+++ b/packages/Redmine/src/Pagination/TraversableResults.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Aedart\Redmine\Pagination;
+
+use Aedart\Contracts\Http\Clients\Requests\Builder;
+use Aedart\Contracts\Redmine\ApiResource;
+use Aedart\Contracts\Redmine\TraversableResults as TraversableResultsInterface;
+use Aedart\Redmine\Pagination\Iterators\ResultsIterator;
+
+/**
+ * Traversable Results
+ *
+ * @author Alin Eugen Deac <ade@rspsystems.com>
+ * @package Aedart\Redmine\Pagination
+ */
+class TraversableResults implements TraversableResultsInterface
+{
+    /**
+     * The results iterator
+     *
+     * @var ResultsIterator<ApiResource>
+     */
+    protected ResultsIterator $iterator;
+
+    /**
+     * TraversableResults
+     *
+     * @param ApiResource $resource
+     * @param Builder $request
+     * @param int $size [optional]
+     */
+    public function __construct(ApiResource $resource, Builder $request, int $size = 10)
+    {
+        $this->iterator = new ResultsIterator($resource, $request, $size);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIterator()
+    {
+        return $this->iterator;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function count()
+    {
+        return $this->iterator->count();
+    }
+}

--- a/packages/Redmine/src/RedmineApiResource.php
+++ b/packages/Redmine/src/RedmineApiResource.php
@@ -13,6 +13,7 @@ use Aedart\Contracts\Redmine\Deletable;
 use Aedart\Contracts\Redmine\Exceptions\ErrorResponseException;
 use Aedart\Contracts\Redmine\Listable;
 use Aedart\Contracts\Redmine\PaginatedResults as PaginatedResultsInterface;
+use Aedart\Contracts\Redmine\TraversableResults as TraversableResultsInterface;
 use Aedart\Contracts\Redmine\Updatable;
 use Aedart\Dto\ArrayDto;
 use Aedart\Redmine\Connections\Connection;
@@ -23,6 +24,7 @@ use Aedart\Redmine\Exceptions\UnexpectedResponse;
 use Aedart\Redmine\Exceptions\UnprocessableEntity;
 use Aedart\Redmine\Exceptions\UnsupportedOperation;
 use Aedart\Redmine\Pagination\PaginatedResults;
+use Aedart\Redmine\Pagination\TraversableResults;
 use Aedart\Redmine\Traits\ConnectionTrait;
 use Aedart\Utils\Json;
 use Aedart\Utils\Str;
@@ -203,6 +205,38 @@ abstract class RedmineApiResource extends ArrayDto implements
             $resource->applyFiltersCallback($filters),
             $limit,
             $offset
+        );
+    }
+
+    /**
+     * Fetch all resources
+     *
+     * Method returns a {@see TraversableResultsInterface} that automatically will perform
+     * paginated requests, as needed, when looping through the results. This is handy, when
+     * you do not wish to manually paginate through available result sets.
+     *
+     * **WARNING**: _Depending on amount of available results and "pool" size, this method
+     * can decrease performance a lot, due to many API requests.
+     * You SHOULD NOT set the pool size too small, if you wish to limit the amount of requests!_
+     *
+     * @param callable|null $filters [optional] Callback that applies filters on the given Request {@see Builder}.
+     *                               The callback MUST return a valid {@see Builder}
+     * @param int $size [optional] The "pool" size - maximum limit of results to fetch per request
+     * @param string|ConnectionInterface|null $connection [optional] Redmine connection profile
+     *
+     * @return TraversableResultsInterface<static>
+     *
+     * @throws Throwable
+     * @throws \Aedart\Contracts\Redmine\Exceptions\RedmineException
+     */
+    public static function all(?callable $filters = null, int $size = 10, $connection = null): TraversableResultsInterface
+    {
+        $resource = static::make([], $connection);
+
+        return new TraversableResults(
+            $resource,
+            $resource->applyFiltersCallback($filters),
+            $size
         );
     }
 

--- a/tests/Integration/Redmine/Pagination/TraversableResultsTest.php
+++ b/tests/Integration/Redmine/Pagination/TraversableResultsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Aedart\Tests\Integration\Redmine\Pagination;
+
+use Aedart\Contracts\Http\Clients\Requests\Builder;
+use Aedart\Contracts\Redmine\Exceptions\UnsupportedOperationException;
+use Aedart\Redmine\Issue;
+use Aedart\Tests\TestCases\Redmine\RedmineTestCase;
+use JsonException;
+use Throwable;
+
+/**
+ * TraversableResultsTest
+ *
+ * @group redmine
+ * @group redmine-pagination
+ * @group redmine-pagination-traversable
+ *
+ * @author Alin Eugen Deac <ade@rspsystems.com>
+ * @package Aedart\Tests\Integration\Redmine\Pagination
+ */
+class TraversableResultsTest extends RedmineTestCase
+{
+    /**
+     * @test
+     *
+     * @throws UnsupportedOperationException
+     * @throws JsonException
+     * @throws Throwable
+     */
+    public function canTraverseAcrossMultipleApiResultsPages()
+    {
+        // Debug
+//        Issue::$debug = true;
+
+        // ----------------------------------------------------------------------- //
+        // Prerequisites - Create a large enough issue set, so that the traversable
+        // if forced to paginate results
+
+        $project = $this->createProject();
+
+        $issueA = $this->createIssue($project->id());
+        $issueB = $this->createIssue($project->id());
+        $issueC = $this->createIssue($project->id());
+        $issueD = $this->createIssue($project->id());
+        $issueE = $this->createIssue($project->id());
+        $issueF = $this->createIssue($project->id());
+        $issueG = $this->createIssue($project->id());
+
+        $allList = [
+            $issueA,
+            $issueB,
+            $issueC,
+            $issueD,
+            $issueE,
+            $issueF,
+            $issueG,
+        ];
+
+        // ----------------------------------------------------------------------- //
+        // Fetch all results
+
+        // The total expected amount of results
+        $expectedTotal = count($allList);
+
+        // The max. pool size / amount of records per results set
+        // SHOULD result in exactly 4 requests.
+        $size = 2;
+
+        // VERY IMPORTANT (at least for live tests) a filter to limit
+        // the issues to the ones we have just created
+        $filter = function (Builder $request) use ($project) {
+            return $request
+                ->where('project_id', $project->id());
+        };
+
+        $issues = Issue::all($filter, $size, $this->liveOrMockedConnection([
+            $this->mockListOfResourcesResponse([ $issueA->toArray(), $issueB->toArray() ], Issue::class, $expectedTotal, $size, 0),
+            $this->mockListOfResourcesResponse([ $issueC->toArray(), $issueD->toArray() ], Issue::class, $expectedTotal, $size, 2),
+            $this->mockListOfResourcesResponse([ $issueE->toArray(), $issueF->toArray() ], Issue::class, $expectedTotal, $size, 4),
+            $this->mockListOfResourcesResponse([ $issueG->toArray() ], Issue::class, $expectedTotal, $size, 6),
+        ]));
+
+        // ----------------------------------------------------------------------- //
+        // Assert traversable...
+
+        // Ensure that it can be counted
+        $this->assertCount($expectedTotal, $issues, 'Invalid amount of results available');
+
+        // Ensure that we can loop through all results - that all requests are performed
+        $c = 0;
+        foreach ($issues as $issue) {
+            $this->assertNotEmpty($issue->id());
+            $c++;
+        }
+
+        $this->assertSame($expectedTotal, $c, 'Unexpected amount of iteration loops');
+
+        // ----------------------------------------------------------------------- //
+        // Cleanup
+
+        foreach ($allList as $issue) {
+            $issue->delete();
+        }
+
+        $project->delete();
+    }
+}


### PR DESCRIPTION
Added a new traversable with an iterator that automatically performs API requests, depending on amount of results shown / available in Redmine.