### PR TITLE
PHP v8.x compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Replaced [`ReflectionParameter::getClass`](https://www.php.net/manual/en/reflectionparameter.getclass.php) call in `IoCPartial` and `ArgumentFaker` with an alternative, because it's deprecated since PHP `v8.0`. [#61](https://github.com/aedart/athenaeum/issues/61).
 * Replaced `socket_create()` call with `tempfile()`, in `JsonTest`. From PHP `v8.0`, the `socket_create()` method returns an object, which can be encoded to Json and thus defeats the purpose of the test. [#61](https://github.com/aedart/athenaeum/issues/61).
+* Converting test model's primary key and auditable id to `string`, to avoid incorrect value comparison in PHP `v8.1`, in the `B0_AuditTrailTest`. [#61](https://github.com/aedart/athenaeum/issues/61).
 * Upgraded phpcs, easy-coding-standard and other vendor-bin dependencies.
 
 ### [v5.24.2](https://github.com/aedart/athenaeum/compare/5.24.1...5.24.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 #### Changed
 
-* Replaced [`ReflectionParameter::getClass`](https://www.php.net/manual/en/reflectionparameter.getclass.php) call in `IoCPartial` with an alternative, because it's deprecated since PHP `v8.0`. [#61](https://github.com/aedart/athenaeum/issues/61).
-* Upgraded phpcs, easy-coding-standard and other vendor-bin dependencies
+* Replaced [`ReflectionParameter::getClass`](https://www.php.net/manual/en/reflectionparameter.getclass.php) call in `IoCPartial` and `ArgumentFaker` with an alternative, because it's deprecated since PHP `v8.0`. [#61](https://github.com/aedart/athenaeum/issues/61).
+* Upgraded phpcs, easy-coding-standard and other vendor-bin dependencies.
 
 ### [v5.24.2](https://github.com/aedart/athenaeum/compare/5.24.1...5.24.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Changed
 
 * Replaced [`ReflectionParameter::getClass`](https://www.php.net/manual/en/reflectionparameter.getclass.php) call in `IoCPartial` and `ArgumentFaker` with an alternative, because it's deprecated since PHP `v8.0`. [#61](https://github.com/aedart/athenaeum/issues/61).
+* Replaced `socket_create()` call with `tempfile()`, in `JsonTest`. From PHP `v8.0`, the `socket_create()` method returns an object, which can be encoded to Json and thus defeats the purpose of the test. [#61](https://github.com/aedart/athenaeum/issues/61).
 * Upgraded phpcs, easy-coding-standard and other vendor-bin dependencies.
 
 ### [v5.24.2](https://github.com/aedart/athenaeum/compare/5.24.1...5.24.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### [Unreleased]
 
+#### Changed
+
+* Replaced [`ReflectionParameter::getClass`](https://www.php.net/manual/en/reflectionparameter.getclass.php) call in `IoCPartial` with an alternative, because it's deprecated since PHP `v8.0`. [#61](https://github.com/aedart/athenaeum/issues/61).
+* Upgraded phpcs, easy-coding-standard and other vendor-bin dependencies
+
 ### [v5.24.2](https://github.com/aedart/athenaeum/compare/5.24.1...5.24.2)
 
 #### Fixed

--- a/composer.json
+++ b/composer.json
@@ -127,7 +127,7 @@
             "@composer bin all update --ansi"
         ],
         "check": [
-            "vendor/bin/phpcs -p --standard=PHPCompatibility --colors --report-full --report-summary ./packages ./tests"
+            "vendor/bin/phpcs -p --standard=PHPCompatibility --colors --report-full --report-summary --runtime-set testVersion 8.0- ./packages ./tests"
         ],
         "cs": "vendor/bin/ecs check --ansi",
         "cs-fix": "vendor/bin/ecs check --fix --ansi"

--- a/ecs.php
+++ b/ecs.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
-use Symplify\EasyCodingStandard\Configuration\Option;
+use Symplify\EasyCodingStandard\ValueObject\Option;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
@@ -29,6 +29,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         'tests/TestCases',
         'tests/Integration',
         'tests/Unit',
+        'tests/Helpers',
         //'src',
     ]);
 

--- a/ecs.php
+++ b/ecs.php
@@ -41,4 +41,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             'tests/Helpers/Dummies/Properties/Accessibility/Person.php'
         ]
     ]);
+
+    // Run all checks parallel (should be much faster)
+    $parameters->set(Option::PARALLEL, true);
 };

--- a/packages/Dto/src/Partials/IoCPartial.php
+++ b/packages/Dto/src/Partials/IoCPartial.php
@@ -109,15 +109,15 @@ trait IoCPartial
         // If there is no class for the given parameter
         // then some kind of primitive data has been provided
         // and thus we need only to return it.
-        $paramClass = $parameter->getClass();
-        if (!isset($paramClass)) {
+        $type = $parameter->getType();
+        if (!isset($type) || $type->isBuiltin()) {
             return $value;
         }
 
         // If the value corresponds to the given expected class,
         // then there is no need to resolve anything from the
         // IoC service container.
-        $className = $paramClass->getName();
+        $className = $type->getName();
         if ($value instanceof $className) {
             return $value;
         }
@@ -171,7 +171,7 @@ trait IoCPartial
     /**
      * Attempts to populate instance, if possible
      *
-     * @param object $instance The instance that must be populated
+     * @param mixed $instance The instance that must be populated
      * @param ReflectionParameter|string $parameter Name of property or property reflection
      * @param mixed $value The value to be passed to the setter method
      *

--- a/packages/Testing/src/Helpers/ArgumentFaker.php
+++ b/packages/Testing/src/Helpers/ArgumentFaker.php
@@ -48,15 +48,14 @@ class ArgumentFaker
         foreach ($parameters as $parameter) {
 
             // Create a mock as "faked" argument, if needed
-            $typeClass = $parameter->getClass();
-            if (isset($typeClass)) {
-                $output[] = static::makeMockFor($typeClass->getName());
+            $type = $parameter->getType();
+            if (isset($type) && !$type->isBuiltin()) {
+                $output[] = static::makeMockFor($type->getName());
                 continue;
             }
 
             // Otherwise, attempt to fake argument for type
-            $type = (string) $parameter->getType();
-            $output[] = static::fakeForType($type, $faker);
+            $output[] = static::fakeForType($type->getName(), $faker);
         }
 
         if (count($output) == 1) {

--- a/packages/Testing/src/Helpers/ArgumentFaker.php
+++ b/packages/Testing/src/Helpers/ArgumentFaker.php
@@ -54,8 +54,15 @@ class ArgumentFaker
                 continue;
             }
 
-            // Otherwise, attempt to fake argument for type
-            $output[] = static::fakeForType($type->getName(), $faker);
+            // Attempt to fake argument for type primitive type
+            if (isset($type) && $type->isBuiltin()) {
+                $output[] = static::fakeForType($type->getName(), $faker);
+                continue;
+            }
+
+            // Otherwise, we request 'null' as a type, which is the same as
+            // for a string, in this case...
+            $output[] = static::fakeForType('null', $faker);
         }
 
         if (count($output) == 1) {

--- a/tests/Integration/Audit/B0_AuditTrailTest.php
+++ b/tests/Integration/Audit/B0_AuditTrailTest.php
@@ -121,7 +121,9 @@ class B0_AuditTrailTest extends AuditTestCase
         $this->assertNull($history->original_data, 'Original data should be null!');
         $this->assertNull($history->changed_data, 'Changed data should be null!');
 
-        $this->assertSame((string)$category->getKey(), $history->auditable_id, 'Id of deleted model not persisted');
+        // Note that we explicitly cast key and auditable id to string, since we do not know
+        // whether an integer or string value is expected.
+        $this->assertSame((string)$category->getKey(), (string)$history->auditable_id, 'Id of deleted model not persisted');
     }
 
     /**
@@ -148,7 +150,9 @@ class B0_AuditTrailTest extends AuditTestCase
         $this->assertNull($history->original_data, 'Original data should be null!');
         $this->assertNull($history->changed_data, 'Changed data should be null!');
 
-        $this->assertSame((string)$category->getKey(), $history->auditable_id, 'Id of deleted model not persisted');
+        // Note that we explicitly cast key and auditable id to string, since we do not know
+        // whether an integer or string value is expected.
+        $this->assertSame((string)$category->getKey(), (string)$history->auditable_id, 'Id of deleted model not persisted');
     }
 
     /**
@@ -174,7 +178,9 @@ class B0_AuditTrailTest extends AuditTestCase
         $this->assertNull($history->original_data, 'Original data should be null!');
         $this->assertNull($history->changed_data, 'Changed data should be null!');
 
-        $this->assertSame((string)$category->getKey(), $history->auditable_id, 'Id of deleted model not persisted');
+        // Note that we explicitly cast key and auditable id to string, since we do not know
+        // whether an integer or string value is expected.
+        $this->assertSame((string)$category->getKey(), (string)$history->auditable_id, 'Id of deleted model not persisted');
     }
 
     /**

--- a/tests/Unit/Utils/JsonTest.php
+++ b/tests/Unit/Utils/JsonTest.php
@@ -50,9 +50,7 @@ class JsonTest extends UnitTestCase
     {
         $this->expectException(JsonException::class);
 
-        $socket = socket_create(AF_UNIX, SOCK_STREAM, 0);
-
-        Json::encode($socket);
+        Json::encode(tmpfile());
     }
 
     /**

--- a/vendor-bin/cs/composer.json
+++ b/vendor-bin/cs/composer.json
@@ -1,9 +1,9 @@
 {
     "require": {
-        "squizlabs/php_codesniffer": "^3.5",
-        "symplify/easy-coding-standard": "^8.2",
+        "squizlabs/php_codesniffer": "^3.6.1",
+        "symplify/easy-coding-standard": "^10.0.2",
         "phpcompatibility/php-compatibility": "^9.3.5",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-        "migrify/config-transformer":  "^0.3"
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+        "symplify/config-transformer": "^10.0.2"
     }
 }


### PR DESCRIPTION
This resolves the relative few PHP `v8.x` compatibility issues that have been identified. Manual execution of all tests has been performed in PHP versions `7.4`, `8.0` and `8.1`.

Additionally, this PR also includes a few vendor-bin dependencies upgrade to phpcs, easy coding standard and PHP-Compatibility (_they proved to be less significant / required than expected_).

Thus, this solves the #61 feature - _at least for now._