### PR TITLE
Migrate to monorepo v10.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,12 @@
     "name": "aedart/athenaeum",
     "description": "Athenaeum is a mono repository; a collection of various PHP packages",
     "license": "BSD-3-Clause",
+    "authors": [
+        {
+            "name": "Alin Eugen Deac",
+            "email": "aedart@gmail.com"
+        }
+    ],
     "require": {
         "php": ">=7.4.0",
         "ext-json": "*",

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\ComposerJsonManipulator\ValueObject\ComposerJsonSection;
+use Symplify\MonorepoBuilder\ValueObject\Option;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+
+    // Location of packages...etc
+    $parameters->set(Option::PACKAGE_DIRECTORIES, [
+        // default value
+        __DIR__ . '/packages',
+    ]);
+
+    // Remove from root composer.json
+    $parameters->set(Option::DATA_TO_REMOVE, [
+        ComposerJsonSection::REQUIRE => [
+            // the line is removed by key, so version is irrelevant, thus *
+            'hanneskod/classtools' => '*',
+            'codeception/codeception' => '*',
+            'orchestra/testbench' => '*',
+            'orchestra/testbench-dusk' => '*',
+            'codeception/module-asserts' => '*',
+        ],
+    ]);
+
+    // Append to root composer.json
+    $parameters->set(Option::DATA_TO_APPEND, [
+        ComposerJsonSection::REQUIRE_DEV => [
+            'ext-sockets' => '*',
+            'ext-curl' => '*',
+            'bamarni/composer-bin-plugin' => '^1.4',
+            'roave/security-advisories' => 'dev-master',
+            'codeception/codeception' => '4.1.*',
+            'orchestra/testbench' => '^6.12.0',
+            'orchestra/testbench-dusk' => '^v6.12.0',
+        ],
+
+        ComposerJsonSection::AUTOLOAD => [
+            'psr-4' => [
+                'Aedart\\' => 'src',
+            ],
+        ],
+
+        ComposerJsonSection::AUTOLOAD_DEV => [
+//            'psr-4' => [
+//                'phpstan/phpstan\\' => '^0.12',
+//            ],
+        ],
+    ]);
+
+    // Packages
+//    $parameters->set(Option::PACKAGE_DIRECTORIES, [
+//
+//    ]);
+
+    // Package alias format
+    $parameters->set(Option::PACKAGE_ALIAS_FORMAT, '<major>.<minor>.x-dev');
+
+    // Section order in composer.json files
+    $parameters->set(Option::SECTION_ORDER, [
+        'name',
+        'type',
+        'description',
+        'keywords',
+        'homepage',
+        'support',
+        'license',
+        'authors',
+        'repositories',
+        'require',
+        'require-dev',
+        'autoload',
+        'autoload-dev',
+        'replace',
+        'provide',
+        'bin',
+        'conflict',
+        'suggest',
+        'scripts',
+        'scripts-descriptions',
+        'config',
+        'minimum-stability',
+        'prefer-stable',
+        'extra',
+    ]);
+};

--- a/monorepo-builder.yml
+++ b/monorepo-builder.yml
@@ -1,7 +1,10 @@
+#
+# DEPRECATED - To be removed before release of Athenaeum version 6.x
+#
 parameters:
     # Project directories
-    package_directories:
-        - 'packages'
+#    package_directories:
+#        - 'packages'
 
     # Sections to merge into root composer.json
     merge_sections:
@@ -12,32 +15,32 @@ parameters:
         - 'suggest'
 
     # for "merge" command
-    data_to_remove:
-        require:
-            'hanneskod/classtools': '*'
-            'codeception/codeception': '*'
-            'orchestra/testbench': '*'
-            'orchestra/testbench-dusk': '*'
-            'codeception/module-asserts': '*'
+#    data_to_remove:
+#        require:
+#            'hanneskod/classtools': '*'
+#            'codeception/codeception': '*'
+#            'orchestra/testbench': '*'
+#            'orchestra/testbench-dusk': '*'
+#            'codeception/module-asserts': '*'
 
     # for "merge" command
-    data_to_append:
-        require-dev:
-            'ext-sockets': "*"
-            'ext-curl': "*"
-            'bamarni/composer-bin-plugin': '^1.4'
-            'roave/security-advisories': 'dev-master'
-#            'hanneskod/classtools': '~1.2'
-            'codeception/codeception': '4.1.*'
-            'codeception/module-asserts': '^1.3'
-            'orchestra/testbench': '^6.12.0'
-            'orchestra/testbench-dusk': '^v6.12.0'
-        autoload:
-            psr-4:
-                'Aedart\': 'src'
-        autoload-dev:
-            psr-4:
-                'Aedart\Tests\': 'tests/'
+#    data_to_append:
+#        require-dev:
+#            'ext-sockets': "*"
+#            'ext-curl': "*"
+#            'bamarni/composer-bin-plugin': '^1.4'
+#            'roave/security-advisories': 'dev-master'
+##            'hanneskod/classtools': '~1.2'
+#            'codeception/codeception': '4.1.*'
+#            'codeception/module-asserts': '^1.3'
+#            'orchestra/testbench': '^6.12.0'
+#            'orchestra/testbench-dusk': '^v6.12.0'
+#        autoload:
+#            psr-4:
+#                'Aedart\': 'src'
+#        autoload-dev:
+#            psr-4:
+#                'Aedart\Tests\': 'tests/'
 
     # for "split" command
     directories_to_repositories:
@@ -66,35 +69,35 @@ parameters:
         packages/Utils: 'git@github.com:aedart/athenaeum-utils.git'
         packages/Validation: 'git@github.com:aedart/athenaeum-validation.git'
 
-    # Package alias format
-    package_alias_format: '<major>.<minor>.x-dev'
+#    # Package alias format
+#    package_alias_format: '<major>.<minor>.x-dev'
 
     # Inline section
     inline_sections: []
 
     # How to sort root composer.json
-    section_order:
-      - 'name'
-      - 'type'
-      - 'description'
-      - 'keywords'
-      - 'homepage'
-      - 'support'
-      - 'license'
-      - 'authors'
-      - 'repositories'
-      - 'require'
-      - 'require-dev'
-      - 'autoload'
-      - 'autoload-dev'
-      - 'replace'
-      - 'provide'
-      - 'bin'
-      - 'conflict'
-      - 'suggest'
-      - 'scripts'
-      - 'scripts-descriptions'
-      - 'config'
-      - 'minimum-stability'
-      - 'prefer-stable'
-      - 'extra'
+#    section_order:
+#      - 'name'
+#      - 'type'
+#      - 'description'
+#      - 'keywords'
+#      - 'homepage'
+#      - 'support'
+#      - 'license'
+#      - 'authors'
+#      - 'repositories'
+#      - 'require'
+#      - 'require-dev'
+#      - 'autoload'
+#      - 'autoload-dev'
+#      - 'replace'
+#      - 'provide'
+#      - 'bin'
+#      - 'conflict'
+#      - 'suggest'
+#      - 'scripts'
+#      - 'scripts-descriptions'
+#      - 'config'
+#      - 'minimum-stability'
+#      - 'prefer-stable'
+#      - 'extra'

--- a/vendor-bin/monorepo/composer.json
+++ b/vendor-bin/monorepo/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "symplify/monorepo-builder": "^7.3"
+        "symplify/monorepo-builder": "^10.0.9"
     }
 }


### PR DESCRIPTION
Upgraded to [Symplify Monorepo Builder v10.x](https://github.com/symplify/monorepo-builder).

*Note*: _The `split` command is no longer offered, which will require either GitHub Actions or something custom_