### PR TITLE
Fix input value "filter" contains a non-scalar value

### DIFF
--- a/packages/Filters/src/BaseProcessor.php
+++ b/packages/Filters/src/BaseProcessor.php
@@ -118,9 +118,14 @@ abstract class BaseProcessor implements Processor
      */
     public function value()
     {
-        return $this->request()->query(
-            $this->parameter()
-        );
+        $request = $this->request();
+        $param = $this->parameter();
+
+        if ($request->query->has($param)) {
+            return $request->query->all($param);
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
Now checking if parameter exists inside the received query and obtaining it safely. Method returns `null`, in case that parameter does not exist inside the http query.

#69