### PR TITLE
Fix Unexpected value for parameter "name": expecting "array"

### DIFF
--- a/packages/Filters/src/BaseProcessor.php
+++ b/packages/Filters/src/BaseProcessor.php
@@ -122,7 +122,7 @@ abstract class BaseProcessor implements Processor
         $param = $this->parameter();
 
         if ($request->query->has($param)) {
-            return $request->query->all($param);
+            return $request->query->all()[$param];
         }
 
         return null;


### PR DESCRIPTION
This fixes the side-effect introduced via #70. 

 #71