### PR TITLE
Improve utils package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Breaking Changes**
 
 * Minimum required PHP version changed to `8.0`.
+* `populate()` method now returns `static` instead of `void`, in `\Aedart\Contracts\Utils\Populatable` interface.
 * `SearchFilter` no longer uses `StopWords` concern (_concern has been removed_). [#63](https://github.com/aedart/athenaeum/issues/63).
 * Replaced `self` return type with `static` for some methods in `\Aedart\Utils\Dates\Duration`.
 * Replaced `self` return type with `static` for some methods in `\Aedart\Utils\Helpers\Invoker`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Minimum required PHP version changed to `8.0`.
 * `SearchFilter` no longer uses `StopWords` concern (_concern has been removed_). [#63](https://github.com/aedart/athenaeum/issues/63).
+* Replaced `self` return type with `static` for some methods in `\Aedart\Utils\Dates\Duration`.
 
 **Non-breaking Changes**
 
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Replaced `fzaninotto/faker` package with `fakerphp/faker`. [#23](https://github.com/aedart/athenaeum/issues/23).
 * Replaced property calls with method calls, on faker instance throughout many tests (_PHP faker deprecated several properties since `v1.14`_). [#23](https://github.com/aedart/athenaeum/issues/23).  
 * Upgraded to [Symplify Monorepo Builder](https://github.com/symplify/monorepo-builder) `v10.x`. [#60](https://github.com/aedart/athenaeum/issues/60), [#65](https://github.com/aedart/athenaeum/pull/65).
+* `\Aedart\Utils\Dates\Duration` now inherits from `Stringable`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 * `\Aedart\Filters\Query\Filters\Concerns\StopWords` has been removed. Component didn't work as intended and caused several issues. [#63](https://github.com/aedart/athenaeum/issues/63).
+* `undot()` from `\Aedart\Utils\Arr`. The `undot()` method has been implemented in Laravel's `Arr`, which acts as the base class for `\Aedart\Utils\Arr`. This change is not breaking.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Maintenance Mode package that offers additional drivers for Laravel's Application, when using `php artisan down`. Available drivers: `'array'` and `'json'`. [#67](https://github.com/aedart/athenaeum/issues/67).
 * Optional `$mode` argument has been added to `\Aedart\Utils\Math::applySeed()`, which specifies the seeding algorithm to use. 
+* Optional seeding algorithm `$mode` argument has been added to `\Aedart\Utils\Arr::randomElement()`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Maintenance Mode package that offers additional drivers for Laravel's Application, when using `php artisan down`. Available drivers: `'array'` and `'json'`. [#67](https://github.com/aedart/athenaeum/issues/67).
 * Optional `$mode` argument has been added to `\Aedart\Utils\Math::applySeed()`, which specifies the seeding algorithm to use. 
 * Optional seeding algorithm `$mode` argument has been added to `\Aedart\Utils\Arr::randomElement()`.
+* Documentation for `\Aedart\Utils\Arr::differenceAssoc()` (_previously undocumented, method was added in `v5.17`_). [#45](https://github.com/aedart/athenaeum/issues/45).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Maintenance Mode package that offers additional drivers for Laravel's Application, when using `php artisan down`. Available drivers: `'array'` and `'json'`. [#67](https://github.com/aedart/athenaeum/issues/67).
+* Optional `$mode` argument has been added to `\Aedart\Utils\Math::applySeed()`, which specifies the seeding algorithm to use. 
 
 ### Changed
 
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `SearchFilter` no longer uses `StopWords` concern (_concern has been removed_). [#63](https://github.com/aedart/athenaeum/issues/63).
 * Replaced `self` return type with `static` for some methods in `\Aedart\Utils\Dates\Duration`.
 * Replaced `self` return type with `static` for some methods in `\Aedart\Utils\Helpers\Invoker`.
+* `$seed` argument can no longer be `null` in `\Aedart\Utils\Math::applySeed()` method.
 
 **Non-breaking Changes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Minimum required PHP version changed to `8.0`.
 * `SearchFilter` no longer uses `StopWords` concern (_concern has been removed_). [#63](https://github.com/aedart/athenaeum/issues/63).
 * Replaced `self` return type with `static` for some methods in `\Aedart\Utils\Dates\Duration`.
+* Replaced `self` return type with `static` for some methods in `\Aedart\Utils\Helpers\Invoker`.
 
 **Non-breaking Changes**
 

--- a/docs/archive/current/utils/array.md
+++ b/docs/archive/current/utils/array.md
@@ -7,6 +7,8 @@ sidebarDepth: 0
 
 Extended version of Laravel's [`Arr` component](https://laravel.com/docs/8.x/helpers#arrays).
 
+[[TOC]]
+
 ## `randomElement()`
 
 Returns a single random element from a given list.
@@ -27,7 +29,11 @@ You can also provide a [seed for the random number generator](https://www.php.ne
 use Aedart\Utils\Arr;
 use Aedart\Utils\Math;
 
-$element = Arr::randomElement(['Jim', 'Sine', 'Ally', 'Gordon'], Math::seed(), MT_RAND_PHP);
+$element = Arr::randomElement(
+    ['Jim', 'Sine', 'Ally', 'Gordon'],
+    Math::seed(),
+    MT_RAND_PHP
+);
 ```
 
 See [`Math::seed()` and `Math::applySeed()` methods ](math.md) for additional information about seeding.

--- a/docs/archive/current/utils/array.md
+++ b/docs/archive/current/utils/array.md
@@ -19,7 +19,7 @@ $element = Arr::randomElement(['Jim', 'Sine', 'Ally', 'Gordon']);
 
 See also Laravel's [`Arr::random`](https://laravel.com/docs/8.x/helpers#method-array-random).
 
-### Seed
+### Seeding
 
 You can also provide a [seed for the random number generator](https://www.php.net/manual/en/function.mt-srand.php). 
 
@@ -27,7 +27,61 @@ You can also provide a [seed for the random number generator](https://www.php.ne
 use Aedart\Utils\Arr;
 use Aedart\Utils\Math;
 
-$element = Arr::randomElement(['Jim', 'Sine', 'Ally', 'Gordon'], Math::seed());
+$element = Arr::randomElement(['Jim', 'Sine', 'Ally', 'Gordon'], Math::seed(), MT_RAND_PHP);
 ```
 
-See [`Math::seed()`](math.md) for additional information about seeding.
+See [`Math::seed()` and `Math::applySeed()` methods ](math.md) for additional information about seeding.
+
+## `differenceAssoc()`
+
+Method computes the difference of two or more multidimensional arrays.
+
+```php
+use Aedart\Utils\Arr;
+
+$original = [
+    'key' => 'person',
+    'value' => 'John Snow',
+    'settings' => [
+        'validation' => [
+            'required' => true,
+            'nullable' => true,
+            'min' => 2,
+            'max' => 50,
+        ]
+    ]
+];
+
+$changed = [
+    'key' => 'person',
+    'value' => 'Smith Snow', // Changed
+    'settings' => [
+        'validation' => [
+            'required' => false, // Changed
+            'nullable' => true,
+            'min' => 2,
+            'max' => 100, // Changed
+        ]
+    ]
+];
+
+$result = Arr::differenceAssoc($original, $changed);
+print_r($result);
+```
+
+The output of the above shown example will be the following:
+
+```php
+Array
+(
+  ['value'] => 'John Snow'
+  ['settings'] => Array
+      (
+          ['validation'] => Array
+              (
+                  ['required'] => 1
+                  ['max'] => 50
+              )
+      )
+)
+```

--- a/docs/archive/current/utils/math.md
+++ b/docs/archive/current/utils/math.md
@@ -5,7 +5,7 @@ sidebarDepth: 0
 
 # Math
 
-Offers a few math related utility methods.
+Offers math related utility methods.
 
 [[TOC]]
 
@@ -33,9 +33,7 @@ mt_srand($seed);
 
 ## `applySeed()`
 
-Seeds the Mersenne Twister Random Number Generator.
-
-See [PHP's documentation](https://www.php.net/manual/en/function.mt-srand) for additional information.
+A wrapper for [PHP's `mt_srand()`](https://www.php.net/manual/en/function.mt-srand) method, which seeds the Mersenne Twister Random Number Generator.
 
 ```php
 use Aedart\Utils\Math;
@@ -51,4 +49,20 @@ $resultB = $list[ array_rand($list, 1) ];
 
 echo $resultA; // b
 echo $resultB; // b
+```
+
+### Seed mode
+
+Use the 3rd argument to specify the seeding algorithm mode: 
+
+```php
+use Aedart\Utils\Math;
+
+$seed = 123456;
+$list = ['a', 'b', 'c', 'd'];
+
+Math::applySeed($seed, MT_RAND_PHP);
+$resultA = $list[ array_rand($list, 1) ];
+
+// ...etc
 ```

--- a/packages/Contracts/src/Utils/Clearable.php
+++ b/packages/Contracts/src/Utils/Clearable.php
@@ -5,9 +5,7 @@ namespace Aedart\Contracts\Utils;
 /**
  * Clearable
  *
- * <br />
- *
- * Component is able to clear it's data, e.g. it's internal collection,
+ * Component is able to clear its data, e.g. it's internal collection,
  * list, set, map,... etc.
  *
  * @author Alin Eugen Deac <aedart@gmail.com>

--- a/packages/Contracts/src/Utils/Populatable.php
+++ b/packages/Contracts/src/Utils/Populatable.php
@@ -7,9 +7,7 @@ use Throwable;
 /**
  * Populatable
  *
- * <br />
- *
- * Component is able to be populated (hydrated) with data.
+ * Able to be populated (hydrated) with data.
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Contracts\Utils
@@ -19,23 +17,18 @@ interface Populatable
     /**
      * Populate this component via an array
      *
-     * <br />
-     *
      * If an empty array is provided, nothing is populated.
-     *
-     * <br />
      *
      * If a value or property is not given via $data, then it
      * is NOT modified / changed.
      *
-     * <br />
-     *
-     * <pre>
+     * Example:
+     * ```
      *      $myComponent->populate([
      *          'myProperty' => 'myPropertyValue',
      *          'myOtherProperty' => 42.5
      *      ])
-     * </pre>
+     * ```
      *
      * @param array $data [optional] Key-value pair, key = property name, value = property value
      *

--- a/packages/Contracts/src/Utils/Populatable.php
+++ b/packages/Contracts/src/Utils/Populatable.php
@@ -32,9 +32,9 @@ interface Populatable
      *
      * @param array $data [optional] Key-value pair, key = property name, value = property value
      *
-     * @return void
+     * @return self
      *
      * @throws Throwable In case that one or more of the given array entries are invalid
      */
-    public function populate(array $data = []): void;
+    public function populate(array $data = []): static;
 }

--- a/packages/Dto/src/Partials/DtoPartial.php
+++ b/packages/Dto/src/Partials/DtoPartial.php
@@ -27,35 +27,32 @@ trait DtoPartial
     /**
      * Populate this component via an array
      *
-     * <br />
-     *
      * If an empty array is provided, nothing is populated.
-     *
-     * <br />
      *
      * If a value or property is not given via $data, then it
      * is NOT modified / changed.
      *
-     * <br />
-     *
-     * <pre>
+     * Example:
+     * ```
      *      $myComponent->populate([
      *          'myProperty' => 'myPropertyValue',
      *          'myOtherProperty' => 42.5
      *      ])
-     * </pre>
+     * ```
      *
      * @param array $data [optional] Key-value pair, key = property name, value = property value
      *
-     * @return void
+     * @return self
      *
      * @throws Throwable In case that one or more of the given array entries are invalid
      */
-    public function populate(array $data = []): void
+    public function populate(array $data = []): static
     {
         foreach ($data as $property => $value) {
             $this->__set($property, $value);
         }
+
+        return $this;
     }
 
     /**

--- a/packages/Dto/src/Partials/IoCPartial.php
+++ b/packages/Dto/src/Partials/IoCPartial.php
@@ -185,9 +185,7 @@ trait IoCPartial
         // Check if instance is populatable and if the given value
         // is an array.
         if ($instance instanceof Populatable && is_array($value)) {
-            $instance->populate($value);
-
-            return $instance;
+            return $instance->populate($value);
         }
 
         // If we reach this part, then we are simply going to fail.

--- a/packages/Http/Clients/src/Requests/Attachment.php
+++ b/packages/Http/Clients/src/Requests/Attachment.php
@@ -62,11 +62,13 @@ class Attachment implements AttachmentInterface
     /**
      * @inheritDoc
      */
-    public function populate(array $data = []): void
+    public function populate(array $data = []): static
     {
         foreach ($data as $property => $value) {
             $this->populateProperty($property, $value);
         }
+
+        return $this;
     }
 
     /**

--- a/packages/Http/Cookies/src/Cookie.php
+++ b/packages/Http/Cookies/src/Cookie.php
@@ -45,11 +45,13 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function populate(array $data = []): void
+    public function populate(array $data = []): static
     {
         foreach ($data as $property => $value) {
             $this->populateProperty($property, $value);
         }
+
+        return $this;
     }
 
     /**

--- a/packages/Redmine/src/Partials/NestedList.php
+++ b/packages/Redmine/src/Partials/NestedList.php
@@ -67,7 +67,7 @@ abstract class NestedList implements
     /**
      * @inheritDoc
      */
-    public function populate(array $data = []): void
+    public function populate(array $data = []): static
     {
         $this->list = array_map(function ($reference) {
             /** @var ArrayDto $type */
@@ -82,6 +82,8 @@ abstract class NestedList implements
             // Set connection, if nested DTO expects one
             return $this->resolveItemConnection($nested);
         }, $data);
+
+        return $this;
     }
 
     /**

--- a/packages/Redmine/src/RedmineApiResource.php
+++ b/packages/Redmine/src/RedmineApiResource.php
@@ -461,7 +461,7 @@ abstract class RedmineApiResource extends ArrayDto implements
     /**
      * @inheritdoc
      */
-    public function populate(array $data = []): void
+    public function populate(array $data = []): static
     {
         parent::populate($data);
 
@@ -472,6 +472,8 @@ abstract class RedmineApiResource extends ArrayDto implements
                 $property->setConnection($this->getConnection());
             }
         }
+
+        return $this;
     }
 
     /**
@@ -479,9 +481,7 @@ abstract class RedmineApiResource extends ArrayDto implements
      */
     public function fill(array $data = [])
     {
-        $this->populate($data);
-
-        return $this;
+        return $this->populate($data);
     }
 
     /**

--- a/packages/Utils/src/Arr.php
+++ b/packages/Utils/src/Arr.php
@@ -4,6 +4,7 @@
 namespace Aedart\Utils;
 
 use Illuminate\Support\Arr as ArrBase;
+use Aedart\Utils\Math;
 use InvalidArgumentException;
 
 /**
@@ -17,16 +18,19 @@ class Arr extends ArrBase
     /**
      * Returns a single random element from given list
      *
+     * @see \Aedart\Utils\Math::applySeed
+     *
      * @param array $list
      * @param int|null $seed [optional] Number to seed the random generator.
+     * @param int $mode [optional] The seeding algorithm to use
      *
      * @return mixed
      */
-    public static function randomElement(array $list, int|null $seed = null): mixed
+    public static function randomElement(array $list, int|null $seed = null, int $mode = MT_RAND_MT19937): mixed
     {
         // Seed generator if required
         if (isset($seed)) {
-            mt_srand($seed);
+            Math::applySeed($seed, $mode);
         }
 
         $index = array_rand($list, 1);

--- a/packages/Utils/src/Arr.php
+++ b/packages/Utils/src/Arr.php
@@ -35,26 +35,6 @@ class Arr extends ArrBase
     }
 
     /**
-     * Un-flatten an array that has been flatten via "dot"
-     *
-     * @see dot
-     *
-     * @param  array|iterable  $array
-     *
-     * @return array
-     */
-    public static function undot($array): array
-    {
-        $output = [];
-
-        foreach ($array as $key => $value) {
-            static::set($output, $key, $value);
-        }
-
-        return $output;
-    }
-
-    /**
      * Computes the difference of multi-dimensional arrays
      *
      * @param array $array The array to compare from

--- a/packages/Utils/src/Arr.php
+++ b/packages/Utils/src/Arr.php
@@ -22,7 +22,7 @@ class Arr extends ArrBase
      *
      * @return mixed
      */
-    public static function randomElement(array $list, int $seed = null)
+    public static function randomElement(array $list, int|null $seed = null): mixed
     {
         // Seed generator if required
         if (isset($seed)) {
@@ -35,7 +35,7 @@ class Arr extends ArrBase
     }
 
     /**
-     * Computes the difference of multi-dimensional arrays
+     * Computes the difference of multidimensional arrays
      *
      * @param array $array The array to compare from
      * @param array ...$arrays Arrays to compare against
@@ -71,7 +71,7 @@ class Arr extends ArrBase
      *
      * @return array
      */
-    protected static function clearNestedEmptyArrays(array $array, $replaceValue = null): array
+    protected static function clearNestedEmptyArrays(array $array, mixed $replaceValue = null): array
     {
         $output = [];
 

--- a/packages/Utils/src/Dates/Duration.php
+++ b/packages/Utils/src/Dates/Duration.php
@@ -4,6 +4,7 @@ namespace Aedart\Utils\Dates;
 
 use DateInterval;
 use DateTime;
+use Stringable;
 
 /**
  * Duration class to handle time intervals with microsecond precision.
@@ -13,21 +14,21 @@ use DateTime;
  * @author steffen
  * @package Aedart\Utils\Dates
  */
-class Duration
+class Duration implements Stringable
 {
     /**
      * Micro Timestamp instance
      *
      * @var MicroTimeStamp
      */
-    protected $microTimeStamp;
+    protected MicroTimeStamp $microTimeStamp;
 
     /**
      * Constructor that can take a DateTime, a DateInterval, a MicroTimeStamp or integer seconds
      *
-     * @param  DateTime|DateInterval|MicroTimeStamp|int|null  $time  [optional]
+     * @param  DateInterval|DateTime|int|MicroTimeStamp|null  $time  [optional]
      */
-    public function __construct($time = null)
+    public function __construct(DateInterval|DateTime|MicroTimeStamp|int|null $time = null)
     {
         if ($time instanceof DateTime) {
             $this->microTimeStamp = MicroTimeStamp::fromDateTime($time);
@@ -44,9 +45,10 @@ class Duration
      * Create instance from either a DateTime, a DateInterval, a MicroTimeStamp or integer seconds
      *
      * @param  DateTime|DateInterval|MicroTimeStamp|int  $interval
+     *
      * @return static
      */
-    public static function from($interval)
+    public static function from(DateTime|DateInterval|MicroTimeStamp|int $interval): static
     {
         return new static($interval);
     }
@@ -55,9 +57,10 @@ class Duration
      * Create instance from time string.
      *
      * @param  string  $timeStr
+     *
      * @return static
      */
-    public static function fromString(string $timeStr): self
+    public static function fromString(string $timeStr): static
     {
         return new static(strtotime($timeStr));
     }
@@ -66,9 +69,10 @@ class Duration
      * Create instance from integer seconds
      *
      * @param  int  $seconds
+     *
      * @return static
      */
-    public static function fromSeconds(int $seconds): self
+    public static function fromSeconds(int $seconds): static
     {
         return new static($seconds);
     }
@@ -78,9 +82,10 @@ class Duration
      *
      * @param  int  $minutes
      * @param  int  $microSeconds  [optional]
+     *
      * @return static
      */
-    public static function fromMinutes(int $minutes, int $microSeconds = 0): self
+    public static function fromMinutes(int $minutes, int $microSeconds = 0): static
     {
         return new static(new MicroTimeStamp($minutes, $microSeconds));
     }
@@ -92,7 +97,7 @@ class Duration
      * @param  int  $minutes  [optional]
      * @return static
      */
-    public static function fromHoursMinutes(int $hours, int $minutes = 0): self
+    public static function fromHoursMinutes(int $hours, int $minutes = 0): static
     {
         // Convert minutes to negative minutes, in case negative hours
         // are provided.
@@ -110,9 +115,10 @@ class Duration
      *
      * @param  string  $hoursMinutes E.g. 00:30, 1:56, -2:30... etc
      * @param  string  $separator  [optional] Hours / minutes separator symbol
+     *
      * @return static
      */
-    public static function fromStringHoursMinutes(string $hoursMinutes, string $separator = ':'): self
+    public static function fromStringHoursMinutes(string $hoursMinutes, string $separator = ':'): static
     {
         list($hours, $minutes) = explode($separator, $hoursMinutes);
 
@@ -126,7 +132,7 @@ class Duration
      * @param  DateTime  $stop
      * @return static
      */
-    public static function fromDifference(DateTime $start, DateTime $stop): self
+    public static function fromDifference(DateTime $start, DateTime $stop): static
     {
         return new static($start->diff($stop));
     }
@@ -134,7 +140,7 @@ class Duration
     /**
      * Start timer
      */
-    public function start()
+    public function start(): void
     {
         $this->microTimeStamp = MicroTimeStamp::fromDateTime(new DateTime());
     }
@@ -142,7 +148,7 @@ class Duration
     /**
      * Stop timer
      */
-    public function stop()
+    public function stop(): void
     {
         $stop = MicroTimeStamp::fromDateTime(new DateTime());
 
@@ -153,9 +159,10 @@ class Duration
      * Add another Duration to this.
      *
      * @param  Duration  $duration
+     *
      * @return self
      */
-    public function add(Duration $duration): self
+    public function add(Duration $duration): static
     {
         $this->microTimeStamp = MicroTimeStamp::fromSecondsFloat($this->microTimeStamp->getAsSecondsFloat() + $duration->asFloatSeconds());
 
@@ -166,9 +173,10 @@ class Duration
      * Subtract another Duration from this.
      *
      * @param  Duration  $duration
+     *
      * @return self
      */
-    public function subtract(Duration $duration): self
+    public function subtract(Duration $duration): static
     {
         $this->microTimeStamp = MicroTimeStamp::fromSecondsFloat($this->microTimeStamp->getAsSecondsFloat() - $duration->asFloatSeconds());
 
@@ -211,6 +219,7 @@ class Duration
      * @see DateInterval::format()
      *
      * @param  string  $format
+     *
      * @return string
      */
     public function format(string $format): string
@@ -257,6 +266,7 @@ class Duration
      * duration surpasses such.
      *
      * @param  bool  $long  [optional]
+     *
      * @return string
      */
     public function toHoursMinutes(bool $long = false): string
@@ -287,6 +297,7 @@ class Duration
      * Format duration as days, hours and minutes.
      *
      * @param  bool  $long  [optional]
+     *
      * @return string
      */
     public function toDaysHoursMinutes(bool $long = false): string
@@ -308,6 +319,7 @@ class Duration
      * Shortest text according to duration length.
      *
      * @param  bool  $long  [optional]
+     *
      * @return string
      */
     public function toString(bool $long = false): string
@@ -326,7 +338,7 @@ class Duration
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->toString(true);
     }

--- a/packages/Utils/src/Dates/MicroTimeStamp.php
+++ b/packages/Utils/src/Dates/MicroTimeStamp.php
@@ -48,6 +48,7 @@ class MicroTimeStamp
      *
      * @param  int  $seconds
      * @param  int  $microSeconds
+     *
      * @return MicroTimeStamp
      */
     public static function fromSeconds(int $seconds, int $microSeconds = 0): MicroTimeStamp
@@ -60,6 +61,7 @@ class MicroTimeStamp
      * Time is relative to Unix epoch.
      *
      * @param  DateTime  $dt
+     *
      * @return MicroTimeStamp
      */
     public static function fromDateTime(DateTime $dt): MicroTimeStamp
@@ -74,6 +76,7 @@ class MicroTimeStamp
      * Only support intervals up to day field.
      *
      * @param  DateInterval  $dt
+     *
      * @return MicroTimeStamp
      */
     public static function fromDateInterval(DateInterval $dt): MicroTimeStamp
@@ -93,6 +96,7 @@ class MicroTimeStamp
      * Factory to create from seconds with fractions.
      *
      * @param  float  $seconds
+     *
      * @return MicroTimeStamp
      */
     public static function fromSecondsFloat(float $seconds): MicroTimeStamp

--- a/packages/Utils/src/Helpers/Invoker.php
+++ b/packages/Utils/src/Helpers/Invoker.php
@@ -19,17 +19,17 @@ class Invoker
     /**
      * The callback to invoke
      *
-     * @var callable|mixed
+     * @var mixed
      */
-    protected $callback;
+    protected mixed $callback;
 
     /**
      * Fallback callback to invoke, if
      * primary callback is not callable
      *
-     * @var callable|mixed
+     * @var mixed
      */
-    protected $fallback = null;
+    protected mixed $fallback = null;
 
     /**
      * Arguments to be passed on to callback
@@ -41,9 +41,9 @@ class Invoker
     /**
      * Invoker constructor.
      *
-     * @param callable|mixed $callback
+     * @param mixed $callback
      */
-    public function __construct($callback)
+    public function __construct(mixed $callback)
     {
         $this->callback = $callback;
     }
@@ -51,11 +51,11 @@ class Invoker
     /**
      * Creates a new invoker instance with given callback
      *
-     * @param callable|mixed $callback
+     * @param mixed $callback
      *
      * @return static
      */
-    public static function invoke($callback): Invoker
+    public static function invoke(mixed $callback): static
     {
         return new static($callback);
     }
@@ -63,11 +63,21 @@ class Invoker
     /**
      * Returns the callback
      *
-     * @return callable|mixed
+     * @return mixed
      */
-    public function getCallback()
+    public function getCallback(): mixed
     {
         return $this->callback;
+    }
+
+    /**
+     * Determine if a callback was set and that it is callable
+     *
+     * @return bool
+     */
+    public function hasCallback(): bool
+    {
+        return isset($this->callback) && is_callable($this->callback);
     }
 
     /**
@@ -76,11 +86,11 @@ class Invoker
      * Method merges given arguments with et. already added
      * arguments.
      *
-     * @param ...$arguments
+     * @param mixed ...$arguments
      *
      * @return self
      */
-    public function with(...$arguments): self
+    public function with(...$arguments): static
     {
         $this->arguments = array_merge(
             $this->arguments,
@@ -104,11 +114,11 @@ class Invoker
      * Add fallback callback to be used, in case that given
      * callback is not callable
      *
-     * @param callable|mixed $callback
+     * @param mixed $callback
      *
      * @return self
      */
-    public function fallback($callback): self
+    public function fallback(mixed $callback): static
     {
         $this->fallback = $callback;
 
@@ -118,11 +128,21 @@ class Invoker
     /**
      * Return evt. fallback callback
      *
-     * @return callable|mixed
+     * @return mixed
      */
-    public function getFallback()
+    public function getFallback(): mixed
     {
         return $this->fallback;
+    }
+
+    /**
+     * Determine if a fallback callback has been set
+     *
+     * @return bool
+     */
+    public function hasFallback(): bool
+    {
+        return isset($this->fallback) && is_callable($this->fallback);
     }
 
     /**
@@ -135,25 +155,23 @@ class Invoker
      *
      * @throws Throwable
      */
-    public function call()
+    public function call(): mixed
     {
         $arguments = $this->getArguments();
 
-        $callback = $this->getCallback();
-        if (is_callable($callback)) {
-            return $this->callCallback($callback, $arguments);
+        if ($this->hasCallback()) {
+            return $this->callCallback($this->getCallback(), $arguments);
         }
 
-        $fallback = $this->getFallback();
-        if (isset($fallback) && is_callable($fallback)) {
-            return $this->callCallback($fallback, $arguments);
+        if ($this->hasFallback()) {
+            return $this->callCallback($this->getFallback(), $arguments);
         }
 
         throw new RuntimeException('Unable to invoke callback or fallback');
     }
 
     /**
-     * Calls the given callback with given arguments and returns it's
+     * Calls the given callback with given arguments and returns its
      * resulting output
      *
      * @param callable $callback
@@ -161,7 +179,7 @@ class Invoker
      *
      * @return mixed
      */
-    protected function callCallback(callable $callback, array $arguments = [])
+    protected function callCallback(callable $callback, array $arguments = []): mixed
     {
         return $callback(...$arguments);
     }

--- a/packages/Utils/src/Helpers/MethodHelper.php
+++ b/packages/Utils/src/Helpers/MethodHelper.php
@@ -2,12 +2,10 @@
 
 namespace Aedart\Utils\Helpers;
 
-use Illuminate\Support\Str;
+use Aedart\Utils\Str;
 
 /**
  * Method Helper
- *
- * <br />
  *
  * Offers various component methods or functions utilities.
  *
@@ -19,11 +17,11 @@ class MethodHelper
     /**
      * Generates a 'getter' name for given property
      *
-     * <b>Example</b><br />
-     * <pre>
+     * Example:
+     * ```
      *        $propertyName = 'logger';
      *        return makeGetterName($propertyName) // Returns getLogger
-     * </pre>
+     * ```
      *
      * @param string $property
      *
@@ -39,11 +37,11 @@ class MethodHelper
     /**
      * Generates a 'setter' name for given property
      *
-     * <b>Example</b><br />
-     * <pre>
+     * Example:
+     * ```
      *        $propertyName = 'logger';
      *        return makeGetterName($propertyName) // Returns setLogger
-     * </pre>
+     * ```
      *
      * @param string $property
      *
@@ -67,7 +65,7 @@ class MethodHelper
      *
      * @return mixed Return value of given method or whatever was given if not callable
      */
-    public static function callOrReturn($method = null, array $parameters = [])
+    public static function callOrReturn(mixed $method = null, array $parameters = []): mixed
     {
         if (is_callable($method)) {
             return $method(...$parameters);

--- a/packages/Utils/src/Helpers/PopulateHelper.php
+++ b/packages/Utils/src/Helpers/PopulateHelper.php
@@ -7,8 +7,6 @@ use Exception;
 /**
  * Populate Helper
  *
- * <br />
- *
  * Offers populate (hydrate) utilities.
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
@@ -27,13 +25,13 @@ class PopulateHelper
      */
     public static function verifyRequired(array $data, array $required): void
     {
-        // Check if the provided data has less entries, than the
+        // Check if the provided data has fewer entries, than the
         // required
         if (count($data) < count($required)) {
             throw new Exception('Cannot populate %s, incorrect amount of properties given');
         }
 
-        // Check that all of the required are present
+        // Check that all the required are present
         foreach ($required as $requiredKey) {
             if (!isset($data[$requiredKey])) {
                 throw new Exception(sprintf('Cannot populate, missing %s', $requiredKey));

--- a/packages/Utils/src/Json.php
+++ b/packages/Utils/src/Json.php
@@ -7,8 +7,6 @@ use JsonException;
 /**
  * Json Utility
  *
- * <br />
- *
  * Offers various Json utilities.
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
@@ -29,7 +27,7 @@ class Json
      *
      * @throws JsonException
      */
-    public static function encode($value, int $options = 0, int $depth = 512): string
+    public static function encode(mixed $value, int $options = 0, int $depth = 512): string
     {
         return json_encode($value, $options |= JSON_THROW_ON_ERROR, $depth);
     }
@@ -53,7 +51,8 @@ class Json
         bool $assoc = false,
         int $depth = 512,
         int $options = 0
-    ) {
+    ): mixed
+    {
         return json_decode($json, $assoc, $depth, $options |= JSON_THROW_ON_ERROR);
     }
 }

--- a/packages/Utils/src/Math.php
+++ b/packages/Utils/src/Math.php
@@ -49,22 +49,23 @@ class Math
         // Source is from php.net's documentation:
         // @see https://www.php.net/manual/en/function.mt-srand.php#refsect1-function.mt-srand-examples
         list($usec, $sec) = explode(' ', microtime());
-        return $sec + $usec * 1000000;
+        return (int) $sec + $usec * 1000000;
     }
 
     /**
      * Seeds the Mersenne Twister Random Number Generator
      *
-     * <b>WARNING</b>: If you choose to seed the random number generator,
+     * **WARNING**: If you choose to seed the random number generator,
      * all methods that depend on it will be affected.
      *
      * @see seed
      * @see https://www.php.net/manual/en/function.mt-srand.php
      *
-     * @param int|null $seed [optional] Seed value
+     * @param int $seed [optional] Seed value
+     * @param int $mode [optional] The algorithm to use
      */
-    public static function applySeed(int $seed = null)
+    public static function applySeed(int $seed = 0, int $mode = MT_RAND_MT19937): void
     {
-        mt_srand($seed);
+        mt_srand($seed, $mode);
     }
 }

--- a/packages/Utils/src/Str.php
+++ b/packages/Utils/src/Str.php
@@ -3,6 +3,7 @@
 namespace Aedart\Utils;
 
 use Illuminate\Support\Str as BaseStr;
+use Illuminate\Support\Stringable;
 
 /**
  * String utility
@@ -18,9 +19,9 @@ class Str extends BaseStr
      * @param string $slug
      * @param string|string[] $separator [optional]
      *
-     * @return \Illuminate\Support\Stringable
+     * @return Stringable
      */
-    public static function slugToWords(string $slug, $separator = ['-', '_', '.'])
+    public static function slugToWords(string $slug, string|array $separator = ['-', '_', '.']): Stringable
     {
         return static::of($slug)->replace($separator, ' ');
     }

--- a/tests/Unit/Utils/ArrTest.php
+++ b/tests/Unit/Utils/ArrTest.php
@@ -55,29 +55,6 @@ class ArrTest extends UnitTestCase
     /**
      * @test
      */
-    public function canUnFlatten()
-    {
-        $source = [
-            'player.strength' => 15,
-            'player.dexterity' => 22,
-            'player.intelligence' => 19
-        ];
-
-        $result = Arr::undot($source);
-        ConsoleDebugger::output($result);
-
-        $this->assertArrayHasKey('player', $result);
-        $this->assertIsArray($result['player']);
-
-        $nested = $result['player'];
-        $this->assertArrayHasKey('strength', $nested);
-        $this->assertArrayHasKey('dexterity', $nested);
-        $this->assertArrayHasKey('intelligence', $nested);
-    }
-
-    /**
-     * @test
-     */
     public function canReturnDifferenceOfAssociate()
     {
         $original = [


### PR DESCRIPTION
PR contains various argument and return types improvements. It also contains a major breaking change:

The `populate()` method now returns `static` instead of `void`, in `\Aedart\Contracts\Utils\Populatable` interface.

Lastly, also improved a few docs, such as #45. 