### PR TITLE
Add mass audit trail recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 ### [Unreleased]
 
+#### Added
+
+* `MultipleModelsChanged` event in Audit package.  
+* `RecordMultipleAuditTrailEntries` listener that handles `MultipleModelsChanged` events. Performs a mass insert of audit trail entries.
+* `AuditTrailEventSubscriber` that will handle registration of Audit Trail related event listeners.
+
+#### Deprecated
+
+* The `audit-trail.listener` configuration setting has been replaced with `audit-trail.subscriber`, in `configs/audit-trail.php`. 
+Will be removed in next major version (_in audit package_).
+
+#### Changed
+
+* `ModelChangedEvents` concern is now able to dispatch "multiple models changed" event, via `dispatchMultipleModelsChanged()` (_in audit package_). 
+
+#### Fixed
+
+* `$performedAt` argument ignored in `\Aedart\Audit\Events\ModelHasChanged`.
+
 ### [v5.26.0](https://github.com/aedart/athenaeum/compare/5.25.0...5.26.0)
 
 #### Changed

--- a/packages/Audit/configs/audit-trail.php
+++ b/packages/Audit/configs/audit-trail.php
@@ -60,14 +60,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Model Has Changed Listener
+    | Event Listeners
     |--------------------------------------------------------------------------
     |
-    | Class path to event listener that is responsible for recording Audit Trail
-    | Entry, based on received "model has changed" event.
+    | Class path to event subscriber that is responsible for recording Audit Trail
+    | Entry, based on received events.
     */
 
+    /**
+     * @deprecated Since 5.27.0, 'listener' option is replaced by 'subscriber' entry.
+     * Will be removed in next major version.
+     */
     'listener' => \Aedart\Audit\Listeners\RecordAuditTrailEntry::class,
+
+    'subscriber' => \Aedart\Audit\Subscribers\AuditTrailEventSubscriber::class,
 
     /*
     |--------------------------------------------------------------------------

--- a/packages/Audit/src/Events/ModelHasChanged.php
+++ b/packages/Audit/src/Events/ModelHasChanged.php
@@ -131,7 +131,8 @@ class ModelHasChanged
         $this->message = $message ?? $this->resolveAuditTrailMessage($model, $type);
 
         // Resolve performed at...
-        $this->performedAt = $this->formatDatetime(Carbon::now());
+        $performedAt = $performedAt ?? Carbon::now();
+        $this->performedAt = $this->formatDatetime($performedAt);
     }
 
     /**

--- a/packages/Audit/src/Events/MultipleModelsChanged.php
+++ b/packages/Audit/src/Events/MultipleModelsChanged.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Aedart\Audit\Events;
+
+use Aedart\Audit\Observers\Concerns;
+use Aedart\Contracts\Audit\Types;
+use Aedart\Database\Model;
+use DateTimeInterface;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Multiple Models Changed Event
+ *
+ * Intended to be dispatched when multiple models have the same
+ * type of change performed, e.g.:
+ * - all records have an attribute set to specific value.
+ * - all records are soft-deleted.
+ * - all records are recovered.
+ *
+ * @author Alin Eugen Deac <ade@rspsystems.com>
+ * @package Aedart\Audit\Events
+ */
+class MultipleModelsChanged
+{
+    use Dispatchable;
+    use Concerns\ModelAttributes;
+
+    /**
+     * The models that have changed
+     *
+     * @var Collection|Model[]
+     */
+    public $models;
+
+    /**
+     * Unique user identifier that caused change
+     *
+     * @var string|int|null
+     */
+    public $user;
+
+    /**
+     * Date and time of when the event happened
+     *
+     * (When user performed action that caused model change)
+     *
+     * @var DateTimeInterface|Carbon|string
+     */
+    public $performedAt;
+
+    /**
+     * The event type
+     *
+     * @var string
+     */
+    public string $type;
+
+    /**
+     * Original data (attributes) before change occurred
+     *
+     * @var array|null
+     */
+    public ?array $original = null;
+
+    /**
+     * Changed data (attributes) after change occurred
+     *
+     * @var array|null
+     */
+    public ?array $changed = null;
+
+    /**
+     * Eventual user provided message associated with the event
+     *
+     * @var string|null
+     */
+    public ?string $message = null;
+
+    /**
+     * Creates new "multiple models changed" event instance
+     *
+     * @param Collection<Model>|Model[] $models The changed models
+     * @param Model|Authenticatable|null $user The user that caused the change
+     * @param string $type [optional] The event type
+     * @param array|null $original [optional] Original data (attributes) before change occurred.
+     *                                        Default's to given model's original data, if none given.
+     * @param array|null $changed [optional] Changed data (attributes) after change occurred.
+     *                                        Default's to given model's changed data, if none given.
+     * @param string|null $message [optional] Eventual user provided message associated with the event
+     * @param DateTimeInterface|Carbon|string|null $performedAt [optional] Date and time of when the event happened.
+     *                                                          Defaults to model's "updated at" value, if available,
+     *                                                          If not, then current date time is used.
+     * @throws Throwable
+     */
+    public function __construct(
+        $models,
+        $user,
+        string $type = Types::UPDATED,
+        ?array $original = null,
+        ?array $changed = null,
+        ?string $message = null,
+        $performedAt = null
+    )
+    {
+        // Resolve models argument
+        if (!($models instanceof Collection) && is_iterable($models)) {
+            $models = collect($models);
+        }
+
+        // Abort if no models are given
+        if ($models->isEmpty()) {
+            throw new RuntimeException('No models are given. Unable to create "multiple models changed" event');
+        }
+
+        $this->models = $models;
+        $this->user = optional($user)->getKey();
+        $this->type = $type;
+
+        // Resolve the original and changed data (attributes). Must be done before
+        // event is serialised. Here, we assume that the same kind of change is made
+        // for all models. So we obtain the first model and use to determine original
+        // and changed data, if nothing specific is given.
+
+        /** @var Model $model */
+        $model = $models->first();
+        $original = $original ?? $this->resolveOriginalData($model, $type);
+        $changed = $changed ?? $this->resolveChangedData($model, $type);
+
+        // Reduce original attributes, and set original and changed
+        $original = $this->reduceOriginal($original, $changed);
+        $this
+            ->withOriginalData($original)
+            ->withChangedData($changed);
+
+        // Resolve evt. message
+        $this->message = $message ?? $this->resolveAuditTrailMessage($model, $type);
+
+        // Resolve performed at...
+        $performedAt = $performedAt ?? Carbon::now();
+        $this->performedAt = $this->formatDatetime($performedAt);
+    }
+
+    /**
+     * Set the original data (attributes) before changed occurred
+     *
+     * @param array|null $data [optional]
+     *
+     * @return self
+     */
+    public function withOriginalData(?array $data = null): self
+    {
+        $this->original = $data;
+
+        return $this;
+    }
+
+    /**
+     * Set the changed data (attributes) after changed occurred
+     *
+     * @param array|null $data [optional]
+     *
+     * @return self
+     */
+    public function withChangedData(?array $data = null): self
+    {
+        $this->changed = $data;
+
+        return $this;
+    }
+}

--- a/packages/Audit/src/Events/MultipleModelsChanged.php
+++ b/packages/Audit/src/Events/MultipleModelsChanged.php
@@ -4,10 +4,10 @@ namespace Aedart\Audit\Events;
 
 use Aedart\Audit\Observers\Concerns;
 use Aedart\Contracts\Audit\Types;
-use Aedart\Database\Model;
 use DateTimeInterface;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Support\Carbon;
 use RuntimeException;

--- a/packages/Audit/src/Listeners/RecordAuditTrailEntry.php
+++ b/packages/Audit/src/Listeners/RecordAuditTrailEntry.php
@@ -49,7 +49,7 @@ class RecordAuditTrailEntry implements ShouldQueue
     public function handle(ModelHasChanged $event)
     {
         // In rare situations, the provided user that caused the event might be force-deleted,
-        // in which case inserting the audit trail entry will fail, due to it's foreign-key
+        // in which case inserting the audit trail entry will fail, due to its foreign-key
         // constraint.
         //
         // Depending on your perspective, you might see this as a design flaw. However, the
@@ -60,7 +60,7 @@ class RecordAuditTrailEntry implements ShouldQueue
         //
         // Nevertheless, to ensure that the insert operation does not fail, we must check
         // whether the user exists or not. If the latter is the case, then we set the user
-        // is to null.
+        // to null.
         $userId = $event->user;
         if (!$this->userExists($userId)) {
             $userId = null;

--- a/packages/Audit/src/Listeners/RecordAuditTrailEntry.php
+++ b/packages/Audit/src/Listeners/RecordAuditTrailEntry.php
@@ -39,7 +39,7 @@ class RecordAuditTrailEntry implements ShouldQueue
     }
 
     /**
-     * Records an new Audit Trail Entry, based on given
+     * Records a new Audit Trail Entry, based on given
      * "model has changed" event
      *
      * @param ModelHasChanged $event

--- a/packages/Audit/src/Listeners/RecordMultipleAuditTrailEntries.php
+++ b/packages/Audit/src/Listeners/RecordMultipleAuditTrailEntries.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Aedart\Audit\Listeners;
+
+use Aedart\Audit\Events\MultipleModelsChanged;
+use Aedart\Audit\Models\Concerns;
+use Aedart\Utils\Json;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Carbon;
+use JsonException;
+use Throwable;
+
+/**
+ * Record Multiple Audit Trail Entries - Event Listener
+ *
+ * @author Alin Eugen Deac <ade@rspsystems.com>
+ * @package Aedart\Audit\Listeners
+ */
+class RecordMultipleAuditTrailEntries implements ShouldQueue
+{
+    use InteractsWithQueue;
+    use Queueable;
+    use Concerns\AuditTrailConfiguration;
+
+    /**
+     * The number of times the queued listener may be attempted.
+     *
+     * @var int
+     */
+    public $tries;
+
+    /**
+     * RecordMultipleAuditTrailEntries constructor.
+     */
+    public function __construct()
+    {
+        $this->afterCommit = true;
+
+        $this->configureQueueSettings();
+    }
+
+    /**
+     * Records multiple new Audit Trail Entry, based on given
+     * "multiple models changed" event
+     *
+     * @param MultipleModelsChanged $event
+     *
+     * @return void
+     *
+     * @throws Throwable
+     */
+    public function handle(MultipleModelsChanged $event)
+    {
+        // Resolve user
+        $userId = $event->user;
+        if (!$this->userExists($userId)) {
+            $userId = null;
+        }
+
+        $entries = $this->prepareEntries($event, $userId);
+
+        $auditTrail = $this->auditTrailModelInstance();
+        $auditTrail->newQuery()
+            ->insert($entries);
+    }
+
+    /*****************************************************************
+     * Internals
+     ****************************************************************/
+
+    /**
+     * Prepare audit trail entries to insert
+     *
+     * @param MultipleModelsChanged $event
+     * @param int|null $userId [optional]
+     *
+     * @return array[]
+     *
+     * @throws JsonException
+     */
+    protected function prepareEntries(MultipleModelsChanged $event, ?int $userId = null): array
+    {
+        $output = [];
+
+        // Obtain first model from collection. We need this to
+        // determine the class path.
+        $first = $event->models->first();
+        $type = get_class($first);
+
+        $original = $this->convertToJson($event->original);
+        $changed = $this->convertToJson($event->changed);
+
+        foreach ($event->models as $model) {
+            $output[] = [
+                'user_id' => $userId,
+                'auditable_type' => $type,
+                'auditable_id' => $model->getKey(),
+                'type' => $event->type,
+                'message' => $event->message,
+                'original_data' => $original,
+                'changed_data' => $changed,
+                'created_at' => Carbon::now(),
+                'performed_at' => $event->performedAt
+            ];
+        }
+
+        return $output;
+    }
+
+    /**
+     * Convert given data to json
+     *
+     * @param array|null $data [optional]
+     *
+     * @return string|null
+     *
+     * @throws JsonException
+     */
+    protected function convertToJson(?array $data = null): ?string
+    {
+        if (!isset($data)) {
+            return null;
+        }
+
+        return Json::encode($data);
+    }
+
+    /**
+     * Determine if a user exists with the given id
+     *
+     * @param string|int $id
+     *
+     * @return bool
+     */
+    protected function userExists($id): bool
+    {
+        $model = $this->auditTrailUserModelInstance();
+
+        return $model
+            ->newQuery()
+            ->where($model->getKeyName(), $id)
+            ->exists();
+    }
+
+    /**
+     * Configure queue settings for this listener
+     *
+     * @return self
+     */
+    protected function configureQueueSettings()
+    {
+        $config = $this->getConfig()->get('audit-trail.queue', []);
+
+        $this->connection = $config['connection'] ?? 'sync';
+        $this->queue = $config['queue'] ?? 'default';
+        $this->delay = $config['delay'] ?? null;
+        $this->tries = $config['retries'] ?? 1;
+
+        return $this;
+    }
+}

--- a/packages/Audit/src/Observers/Concerns/ModelChangedEvents.php
+++ b/packages/Audit/src/Observers/Concerns/ModelChangedEvents.php
@@ -4,10 +4,13 @@
 namespace Aedart\Audit\Observers\Concerns;
 
 use Aedart\Audit\Events\ModelHasChanged;
+use Aedart\Audit\Events\MultipleModelsChanged;
 use Aedart\Support\Helpers\Auth\AuthTrait;
 use Aedart\Support\Helpers\Events\DispatcherTrait;
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Throwable;
 
 /**
  * Concerns Model Changed Events
@@ -45,6 +48,50 @@ trait ModelChangedEvents
     }
 
     /**
+     * Dispatches multiple models changed event
+     *
+     * @param Collection<Model>|Model[] $models The changed models
+     * @param string $type [optional] The event type
+     * @param array|null $original [optional] Original data (attributes) before change occurred.
+     *                                        Default's to given model's original data, if none given.
+     * @param array|null $changed [optional] Changed data (attributes) after change occurred.
+     *                                        Default's to given model's changed data, if none given.
+     * @param string|null $message [optional] Eventual user provided message associated with the event
+     *
+     * @return self
+     *
+     * @throws Throwable
+     */
+    public function dispatchMultipleModelsChanged(
+        $models,
+        string $type,
+        ?array $original = null,
+        ?array $changed = null,
+        ?string $message = null
+    ) {
+        // Determine if event dispatching should be aborted, based on first model's
+        // "must record next change" state.
+        $first = $models->first();
+
+        // Abort if model does not wish to record its next change
+        if (method_exists($first, 'mustRecordNextChange') && !$first->mustRecordNextChange()) {
+            return $this;
+        }
+
+        $event = $this->makeMultipleModelsChangedEvent(
+            $models,
+            $type,
+            $original,
+            $changed,
+            $message
+        );
+
+        $this->getDispatcher()->dispatch($event);
+
+        return $this;
+    }
+
+    /**
      * Creates a new "model has changed" event
      *
      * @param Model $model The model that has changed
@@ -63,6 +110,37 @@ trait ModelChangedEvents
             $type,
             null, // Original data is resolved from model in this context
             null, // Changed data is resolved from model in this context
+            $message
+        );
+    }
+
+    /**
+     * Creates a new "multiple models changed" event
+     *
+     * @param Collection<Model>|Model[] $models The changed models
+     * @param string $type [optional] The event type
+     * @param array|null $original [optional] Original data (attributes) before change occurred.
+     *                                        Default's to given model's original data, if none given.
+     * @param array|null $changed [optional] Changed data (attributes) after change occurred.
+     *                                        Default's to given model's changed data, if none given.
+     * @param string|null $message [optional] Eventual user provided message associated with the event
+     *
+     * @return MultipleModelsChanged
+     */
+    public function makeMultipleModelsChangedEvent(
+        $models,
+        string $type,
+        ?array $original = null,
+        ?array $changed = null,
+        ?string $message = null
+    ): MultipleModelsChanged
+    {
+        return new MultipleModelsChanged(
+            $models,
+            $this->user(),
+            $type,
+            $original,
+            $changed,
             $message
         );
     }

--- a/packages/Audit/src/Providers/AuditTrailServiceProvider.php
+++ b/packages/Audit/src/Providers/AuditTrailServiceProvider.php
@@ -4,6 +4,7 @@ namespace Aedart\Audit\Providers;
 
 use Aedart\Audit\Events\ModelHasChanged;
 use Aedart\Audit\Listeners\RecordAuditTrailEntry;
+use Aedart\Audit\Subscribers\AuditTrailEventSubscriber;
 use Aedart\Support\Helpers\Config\ConfigTrait;
 use Aedart\Support\Helpers\Events\DispatcherTrait;
 use Illuminate\Support\ServiceProvider;
@@ -40,8 +41,7 @@ class AuditTrailServiceProvider extends ServiceProvider
      */
     protected function registerEventListener()
     {
-        $listener = $this->getConfig()->get('audit-trail.listener', RecordAuditTrailEntry::class);
-
-        $this->getDispatcher()->listen(ModelHasChanged::class, $listener);
+        $subscriber = $this->getConfig()->get('audit-trail.subscriber', AuditTrailEventSubscriber::class);
+        $this->getDispatcher()->subscribe($subscriber);
     }
 }

--- a/packages/Audit/src/Subscribers/AuditTrailEventSubscriber.php
+++ b/packages/Audit/src/Subscribers/AuditTrailEventSubscriber.php
@@ -4,6 +4,7 @@ namespace Aedart\Audit\Subscribers;
 
 use Aedart\Audit\Events\ModelHasChanged;
 use Aedart\Audit\Listeners\RecordAuditTrailEntry;
+use Aedart\Support\Helpers\Config\ConfigTrait;
 use Illuminate\Contracts\Events\Dispatcher;
 
 /**
@@ -14,6 +15,8 @@ use Illuminate\Contracts\Events\Dispatcher;
  */
 class AuditTrailEventSubscriber
 {
+    use ConfigTrait;
+
     /**
      * Register the listeners for the subscriber.
      *
@@ -23,10 +26,15 @@ class AuditTrailEventSubscriber
      */
     public function subscribe(Dispatcher $dispatcher)
     {
+        // TODO: This can safely be removed in next major version
+        // To ensure that we keep backwards compatibility, we load evt. custom listener that has
+        // been specified.
+        $recordSingleEntryListener = $this->getConfig()->get('audit-trail.listener', RecordAuditTrailEntry::class);
+
         // Handle change event for a single model
         $dispatcher->listen(
             ModelHasChanged::class,
-            [RecordAuditTrailEntry::class, 'handle']
+            [$recordSingleEntryListener, 'handle']
         );
     }
 }

--- a/packages/Audit/src/Subscribers/AuditTrailEventSubscriber.php
+++ b/packages/Audit/src/Subscribers/AuditTrailEventSubscriber.php
@@ -3,7 +3,9 @@
 namespace Aedart\Audit\Subscribers;
 
 use Aedart\Audit\Events\ModelHasChanged;
+use Aedart\Audit\Events\MultipleModelsChanged;
 use Aedart\Audit\Listeners\RecordAuditTrailEntry;
+use Aedart\Audit\Listeners\RecordMultipleAuditTrailEntries;
 use Aedart\Support\Helpers\Config\ConfigTrait;
 use Illuminate\Contracts\Events\Dispatcher;
 
@@ -35,6 +37,12 @@ class AuditTrailEventSubscriber
         $dispatcher->listen(
             ModelHasChanged::class,
             [$recordSingleEntryListener, 'handle']
+        );
+
+        // Handle multiple models changed event
+        $dispatcher->listen(
+            MultipleModelsChanged::class,
+            [RecordMultipleAuditTrailEntries::class, 'handle']
         );
     }
 }

--- a/packages/Audit/src/Subscribers/AuditTrailEventSubscriber.php
+++ b/packages/Audit/src/Subscribers/AuditTrailEventSubscriber.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Aedart\Audit\Subscribers;
+
+use Aedart\Audit\Events\ModelHasChanged;
+use Aedart\Audit\Listeners\RecordAuditTrailEntry;
+use Illuminate\Contracts\Events\Dispatcher;
+
+/**
+ * Audit Trail Event Subscriber
+ *
+ * @author Alin Eugen Deac <ade@rspsystems.com>
+ * @package Aedart\Audit\Subscribers
+ */
+class AuditTrailEventSubscriber
+{
+    /**
+     * Register the listeners for the subscriber.
+     *
+     * @param Dispatcher $dispatcher
+     *
+     * @return void
+     */
+    public function subscribe(Dispatcher $dispatcher)
+    {
+        // Handle change event for a single model
+        $dispatcher->listen(
+            ModelHasChanged::class,
+            [RecordAuditTrailEntry::class, 'handle']
+        );
+    }
+}

--- a/tests/TestCases/Audit/AuditTestCase.php
+++ b/tests/TestCases/Audit/AuditTestCase.php
@@ -139,6 +139,30 @@ abstract class AuditTestCase extends LaravelTestCase
     }
 
     /**
+     * Generates multiple "categories" records data
+     *
+     * @param int $amount [optional]
+     * @param array $data [optional]
+     *
+     * @return array
+     */
+    public function makeCategoriesData(int $amount = 3, array $data = []): array
+    {
+        $faker = $this->getFaker();
+
+        $output = [];
+        while($amount--) {
+            $output[] = array_merge([
+                'slug' => $faker->unique()->slug(3),
+                'name' => $faker->words(4, true),
+                'description' => $faker->sentence()
+            ], $data);
+        }
+
+        return $output;
+    }
+
+    /**
      * Creates and persists a new dummy user
      *
      * @param array $attributes [optional]

--- a/tests/_data/configs/audit/audit-trail.php
+++ b/tests/_data/configs/audit/audit-trail.php
@@ -60,14 +60,14 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Model Has Changed Listener
+    | Event Listeners
     |--------------------------------------------------------------------------
     |
-    | Class path to event listener that is responsible for recording Audit Trail
-    | Entry, based on received "model has changed" event.
+    | Class path to event subscriber that is responsible for recording Audit Trail
+    | Entry, based on received events.
     */
 
-    'listener' => \Aedart\Audit\Listeners\RecordAuditTrailEntry::class,
+    'subscriber' => \Aedart\Audit\Subscribers\AuditTrailEventSubscriber::class,
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Adds possibility to record multiple changes, of the same type, for multiple models. E.g. 

 * all records have an attribute set to specific value.
 * all records are soft-deleted.
 * all records are recovered.

Unlike the regular "model has changed" event, this "bulk" operation event must be manually dispatched.