### PR TITLE
Adapt env detection and handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Maintenance Mode package that offers additional drivers for Laravel's Application, when using `php artisan down`. Available drivers: `'array'` and `'json'`. [#67](https://github.com/aedart/athenaeum/issues/67).
+* `environmentPath()` added in `\Aedart\Contracts\Core\Application`. Method was previously defined by Laravel's foundation `Application` interface, but was removed in version `9.x`.
 * Optional `$mode` argument has been added to `\Aedart\Utils\Math::applySeed()`, which specifies the seeding algorithm to use. 
 * Optional seeding algorithm `$mode` argument has been added to `\Aedart\Utils\Arr::randomElement()`.
 * `hasCallback()` and `hasFallback()` methods added in `\Aedart\Utils\Helpers\Invoker`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Maintenance Mode package that offers additional drivers for Laravel's Application, when using `php artisan down`. Available drivers: `'array'` and `'json'`. [#67](https://github.com/aedart/athenaeum/issues/67).
-* `environmentPath()` added in `\Aedart\Contracts\Core\Application`. Method was previously defined by Laravel's foundation `Application` interface, but was removed in version `9.x`.
+* `EnvironmentHandler` interface in Core package, as a replacement for the application environment related methods, that were removed from Laravel's foundation `Application` interface in version `9.x`.
 * Optional `$mode` argument has been added to `\Aedart\Utils\Math::applySeed()`, which specifies the seeding algorithm to use. 
 * Optional seeding algorithm `$mode` argument has been added to `\Aedart\Utils\Arr::randomElement()`.
 * `hasCallback()` and `hasFallback()` methods added in `\Aedart\Utils\Helpers\Invoker`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `\Illuminate\Routing\Redirector` imported into `\Aedart\Contracts\Support\Helpers\Routing\RedirectAware` interface. This created unintended dependency on Laravel package.
 * `\Illuminate\Session\SessionManager` imported into `\Aedart\Contracts\Support\Helpers\Session\SessionManagerAware` interface. This created unintended dependency on Laravel package.
 * `\Illuminate\View\Compilers\BladeCompiler` imported into `\Aedart\Contracts\Support\Helpers\View\BladeAware` interface. This created unintended dependency on Laravel package.
+* `$_ENV['APP_ENV']` and `$_SERVER['APP_ENV']` not unset after each Application test, causing environment detecting tests to fail, in `\Aedart\Testing\Athenaeum\ApplicationInitiator`.
 * `Codeception\TestCase\Test` class not found, in `\Aedart\Tests\Integration\Laravel\ApplicationInitiatorTest` (_happened after upgrade to the latest version of Codeception_). 
 * `LoadSpecifiedConfiguration` may nor inherit from final class. `\Aedart\Testing\Laravel\Bootstrap\LoadSpecifiedConfiguration` no longer inherits from `Orchestra\Testbench\Bootstrap\LoadConfiguration`, which has been declared final (_happened after upgrade to the latest version of Orchestra_).
 

--- a/packages/Contracts/src/Core/Application.php
+++ b/packages/Contracts/src/Core/Application.php
@@ -28,6 +28,13 @@ interface Application extends IoC,
     public function publicPath();
 
     /**
+     * Get the fully qualified path to the environment file.
+     *
+     * @return string
+     */
+    public function environmentPath();
+
+    /**
      * Determine if running in "local" environment
      *
      * @return bool

--- a/packages/Contracts/src/Core/Application.php
+++ b/packages/Contracts/src/Core/Application.php
@@ -18,6 +18,7 @@ use Throwable;
  * @package Aedart\Contracts\Core
  */
 interface Application extends IoC,
+    EnvironmentHandler,
     LaravelApplication
 {
     /**
@@ -26,13 +27,6 @@ interface Application extends IoC,
      * @return string
      */
     public function publicPath();
-
-    /**
-     * Get the fully qualified path to the environment file.
-     *
-     * @return string
-     */
-    public function environmentPath();
 
     /**
      * Determine if running in "local" environment

--- a/packages/Contracts/src/Core/Application.php
+++ b/packages/Contracts/src/Core/Application.php
@@ -121,7 +121,7 @@ interface Application extends IoC,
      *
      * @throws Throwable
      */
-    public function run(?callable $callback = null): void;
+    public function run(callable|null $callback = null): void;
 
     /**
      * Get the application's core "bootstrappers"

--- a/packages/Contracts/src/Core/EnvironmentHandler.php
+++ b/packages/Contracts/src/Core/EnvironmentHandler.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Aedart\Contracts\Core;
+
+use Closure;
+
+/**
+ * Environment Handler
+ *
+ * @author Alin Eugen Deac <aedart@gmail.com>
+ * @package Aedart\Contracts\Core
+ */
+interface EnvironmentHandler
+{
+    /**
+     * Get or check the current application environment.
+     *
+     * @see \Illuminate\Contracts\Foundation\Application::environment
+     *
+     * @param  string|array  $environments
+     *
+     * @return string|bool
+     */
+    public function environment(...$environments): string|bool;
+
+    /**
+     * Detect the application's current environment, using given callback
+     *
+     * @param  Closure  $callback
+     *
+     * @return string
+     */
+    public function detectEnvironment(Closure $callback): string;
+
+    /**
+     * Set the environment file to be loaded
+     *
+     * @param  string  $file
+     *
+     * @return self
+     */
+    public function loadEnvironmentFrom(string $file): static;
+
+    /**
+     * Get the fully qualified path to the environment file.
+     *
+     * @return string
+     */
+    public function environmentPath(): string;
+
+    /**
+     * Get the environment file the application is using.
+     *
+     * @return string
+     */
+    public function environmentFile(): string;
+
+    /**
+     * Get the fully qualified path to the environment file.
+     *
+     * @return string
+     */
+    public function environmentFilePath(): string;
+}

--- a/packages/Core/src/Application.php
+++ b/packages/Core/src/Application.php
@@ -236,7 +236,7 @@ class Application extends IoC implements
     /**
      * @inheritDoc
      */
-    public function environmentPath()
+    public function environmentPath(): string
     {
         return $this->getPathsContainer()->environmentPath();
     }
@@ -260,7 +260,7 @@ class Application extends IoC implements
     /**
      * @inheritDoc
      */
-    public function environment(...$environments)
+    public function environment(...$environments): string|bool
     {
         if (count($environments) > 0) {
             $search = is_array($environments[0])
@@ -428,38 +428,25 @@ class Application extends IoC implements
     }
 
     /**
-     * TODO: Extract into own interface?
-     *
-     * Detect the application's current environment.
-     *
-     * @param  Closure  $callback
-     * @return string
+     * @inheritdoc
      */
-    public function detectEnvironment(Closure $callback)
+    public function detectEnvironment(Closure $callback): string
     {
         return $this['env'] = $callback();
     }
 
     /**
-     * TODO: Extract into own interface?
-     *
-     * Get the environment file the application is using.
-     *
-     * @return string
+     * @inheritdoc
      */
-    public function environmentFile()
+    public function environmentFile(): string
     {
         return $this->environmentFile;
     }
 
     /**
-     * TODO: Extract into own interface?
-     *
-     * Get the fully qualified path to the environment file.
-     *
-     * @return string
+     * @inheritdoc
      */
-    public function environmentFilePath()
+    public function environmentFilePath(): string
     {
         return $this->getPathsContainer()->environmentPath($this->environmentPath());
     }
@@ -560,14 +547,9 @@ class Application extends IoC implements
     }
 
     /**
-     * TODO: Extract into own interface?
-     *
-     * Set the environment file to be loaded during bootstrapping.
-     *
-     * @param  string  $file
-     * @return self
+     * @inheritdoc
      */
-    public function loadEnvironmentFrom($file)
+    public function loadEnvironmentFrom(string $file): static
     {
         $this->environmentFile = $file;
 

--- a/packages/Core/src/Application.php
+++ b/packages/Core/src/Application.php
@@ -45,7 +45,6 @@ use Closure;
 use Illuminate\Contracts\Foundation\Application as LaravelApplicationInterface;
 use Illuminate\Contracts\Foundation\MaintenanceMode;
 use Illuminate\Support\ServiceProvider;
-use LogicException;
 use Throwable;
 
 /**

--- a/packages/Core/src/Application.php
+++ b/packages/Core/src/Application.php
@@ -745,7 +745,7 @@ class Application extends IoC implements
     /**
      * @inheritDoc
      */
-    public function run(?callable $callback = null): void
+    public function run(callable|null $callback = null): void
     {
         if ($this->isRunning()) {
             return;

--- a/packages/Core/src/Application.php
+++ b/packages/Core/src/Application.php
@@ -40,6 +40,7 @@ use Aedart\Service\Registrar;
 use Aedart\Service\Traits\ServiceProviderRegistrarTrait;
 use Aedart\Support\Helpers\Config\ConfigTrait;
 use Aedart\Support\Helpers\Events\DispatcherTrait;
+use Aedart\Utils\Str;
 use Closure;
 use Illuminate\Contracts\Foundation\Application as LaravelApplicationInterface;
 use Illuminate\Contracts\Foundation\MaintenanceMode;
@@ -263,9 +264,11 @@ class Application extends IoC implements
     public function environment(...$environments)
     {
         if (count($environments) > 0) {
-            $search = is_array($environments) ? $environments : [ $environments ];
+            $search = is_array($environments[0])
+                ? $environments[0]
+                : $environments;
 
-            return in_array($this['env'], $search);
+            return Str::is($search, $this['env']);
         }
 
         return $this['env'];

--- a/packages/Testing/src/Athenaeum/ApplicationInitiator.php
+++ b/packages/Testing/src/Athenaeum/ApplicationInitiator.php
@@ -85,6 +85,10 @@ trait ApplicationInitiator
         $this->app->destroy();
         $this->app = null;
 
+        // Ensure to clear application environment. This is only need
+        // for tests - DO NOT DO THIS IN PRODUCTION!
+        unset($_ENV['APP_ENV'], $_SERVER['APP_ENV']);
+
         Env::enablePutenv();
 
         return true;

--- a/tests/Integration/Core/Application/A2_PathsTest.php
+++ b/tests/Integration/Core/Application/A2_PathsTest.php
@@ -141,7 +141,7 @@ class A2_PathsTest extends AthenaeumCoreTestCase
      */
     public function returnsPathInBaseDir()
     {
-        $path = 'readme.' . $this->getFaker()->fileExtension;
+        $path = 'readme.' . $this->getFaker()->fileExtension();
 
         $result = base_path($path);
 
@@ -155,7 +155,7 @@ class A2_PathsTest extends AthenaeumCoreTestCase
      */
     public function returnsPathInBootstrapDir()
     {
-        $path = 'readme.' . $this->getFaker()->fileExtension;
+        $path = 'readme.' . $this->getFaker()->fileExtension();
 
         $result = bootstrap_path($path);
 
@@ -169,7 +169,7 @@ class A2_PathsTest extends AthenaeumCoreTestCase
      */
     public function returnsPathInConfigDir()
     {
-        $path = 'readme.' . $this->getFaker()->fileExtension;
+        $path = 'readme.' . $this->getFaker()->fileExtension();
 
         $result = config_path($path);
 
@@ -183,7 +183,7 @@ class A2_PathsTest extends AthenaeumCoreTestCase
      */
     public function returnsPathInDatabaseDir()
     {
-        $path = 'readme.' . $this->getFaker()->fileExtension;
+        $path = 'readme.' . $this->getFaker()->fileExtension();
 
         $result = database_path($path);
 
@@ -197,7 +197,7 @@ class A2_PathsTest extends AthenaeumCoreTestCase
      */
     public function returnsPathInEnvironmentDir()
     {
-        $path = 'readme.' . $this->getFaker()->fileExtension;
+        $path = 'readme.' . $this->getFaker()->fileExtension();
 
         $result = environment_path($path);
 
@@ -211,7 +211,7 @@ class A2_PathsTest extends AthenaeumCoreTestCase
      */
     public function returnsPathInResourceDir()
     {
-        $path = 'readme.' . $this->getFaker()->fileExtension;
+        $path = 'readme.' . $this->getFaker()->fileExtension();
 
         $result = resource_path($path);
 
@@ -225,7 +225,7 @@ class A2_PathsTest extends AthenaeumCoreTestCase
      */
     public function returnsPathInStorageDir()
     {
-        $path = 'readme.' . $this->getFaker()->fileExtension;
+        $path = 'readme.' . $this->getFaker()->fileExtension();
 
         $result = storage_path($path);
 
@@ -239,7 +239,7 @@ class A2_PathsTest extends AthenaeumCoreTestCase
      */
     public function returnsPathInPublicDir()
     {
-        $path = 'readme.' . $this->getFaker()->fileExtension;
+        $path = 'readme.' . $this->getFaker()->fileExtension();
 
         $result = public_path($path);
 


### PR DESCRIPTION
The fixes some broken tests, which were unable to detect `APP_ENV`, after it previously was set (_only tests were affected_).
Also, added a new `EnvironmentHandler` interface, which the core `Application` now  inherits from.