### PR TITLE
Remove cache related paths

### DIFF
--- a/packages/Core/src/Application.php
+++ b/packages/Core/src/Application.php
@@ -417,17 +417,6 @@ class Application extends IoC implements
     }
 
     /**
-     * TODO: Can this be removed?
-     *
-     * @inheritDoc
-     */
-    public function configurationIsCached()
-    {
-        // By default, this application does not cache configuration.
-        return false;
-    }
-
-    /**
      * @inheritdoc
      */
     public function detectEnvironment(Closure $callback): string
@@ -449,52 +438,6 @@ class Application extends IoC implements
     public function environmentFilePath(): string
     {
         return $this->getPathsContainer()->environmentPath($this->environmentPath());
-    }
-
-    /**
-     * TODO: Can this be removed?
-     *
-     * @inheritDoc
-     */
-    public function getCachedConfigPath()
-    {
-        // Not used by this application - overwrite if required
-        return '';
-    }
-
-    /**
-     * TODO: Can this be removed?
-     *
-     * @inheritDoc
-     */
-    public function getCachedServicesPath()
-    {
-        // Not used by this application - overwrite if required
-        return '';
-    }
-
-    /**
-     * TODO: Is this needed?
-     *
-     * Get the path to the cached packages.php file.
-     *
-     * @return string
-     */
-    public function getCachedPackagesPath()
-    {
-        // Not used by this application - overwrite if required
-        return '';
-    }
-
-    /**
-     * TODO: Can this be removed?
-     *
-     * @inheritDoc
-     */
-    public function getCachedRoutesPath()
-    {
-        // Not used by this application - overwrite if required
-        return '';
     }
 
     /**
@@ -554,17 +497,6 @@ class Application extends IoC implements
         $this->environmentFile = $file;
 
         return $this;
-    }
-
-    /**
-     * TODO: Can this be removed?
-     *
-     * @inheritDoc
-     */
-    public function routesAreCached()
-    {
-        // By default, this application does not offer routing
-        return false;
     }
 
     /**

--- a/tests/Integration/Core/Application/A2_PathsTest.php
+++ b/tests/Integration/Core/Application/A2_PathsTest.php
@@ -247,48 +247,4 @@ class A2_PathsTest extends AthenaeumCoreTestCase
 
         $this->assertStringContainsString($path, $result);
     }
-
-    /*****************************************************************
-     * Unsupported "cache" paths
-     ****************************************************************/
-
-    /**
-     * @test
-     */
-    public function canReadCachedConfigPath()
-    {
-        $path = $this->app->getCachedConfigPath();
-
-        $this->assertEmpty($path);
-    }
-
-    /**
-     * @test
-     */
-    public function canReadCachedServicesPath()
-    {
-        $path = $this->app->getCachedServicesPath();
-
-        $this->assertEmpty($path);
-    }
-
-    /**
-     * @test
-     */
-    public function canReadCachedPackagesPath()
-    {
-        $path = $this->app->getCachedPackagesPath();
-
-        $this->assertEmpty($path);
-    }
-
-    /**
-     * @test
-     */
-    public function canReadCachedRoutesPath()
-    {
-        $path = $this->app->getCachedRoutesPath();
-
-        $this->assertEmpty($path);
-    }
 }


### PR DESCRIPTION
Since Laravel `v9.x`, the various cache paths util methods have been extracted into separate interfaces. This means that the Core application not longer needs to offer an implementation for these. Furthermore, these were never supported by the Core App.