### PR TITLE
Change datetime type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `populate()` method now returns `static` instead of `void`, in `\Aedart\Contracts\Utils\Populatable` interface.
 * `all()` method added in `ApiResource` interface (_change is only breaking if you have custom implementation of interface_). [#54](https://github.com/aedart/athenaeum/issues/54).
 * `fresh()` method added in Http Client `Manager` (_change is only breaking if you have custom implementation of interface_). [#51](https://github.com/aedart/athenaeum/issues/51).
+* Replaced `\DateTime` with `\DateTimeInterface` for all date related aware-of helpers. The `\Aedart\Contracts\Utils\DataTypes::DATE_TIME_TYPE` has also been changed. [#75](https://github.com/aedart/athenaeum/issues/75). 
 * `SearchFilter` no longer uses `StopWords` concern (_concern has been removed_). [#63](https://github.com/aedart/athenaeum/issues/63).
 * Return type of `package()` and `application()` is now set to `\Aedart\Contracts\Utils\Packages\Version`, in `\Aedart\Utils\Version`.  [#68](https://github.com/aedart/athenaeum/issues/68).
 * `PackageVersionException` is now thrown, when version cannot be obtained for a package, in `\Aedart\Utils\Version::package()`. [#68](https://github.com/aedart/athenaeum/issues/68).

--- a/docs/archive/current/support/properties/available-helpers.md
+++ b/docs/archive/current/support/properties/available-helpers.md
@@ -122,7 +122,7 @@ ___
 
 
 ___
-`\DateTime` Date of anniversary
+`\DateTimeInterface` Date of anniversary
 
 *Interface*: `Aedart\Contracts\Support\Properties\Dates\AnniversaryAware`
 
@@ -196,7 +196,7 @@ ___
 
 
 ___
-`\DateTime` Date of birth
+`\DateTimeInterface` Date of birth
 
 *Interface*: `Aedart\Contracts\Support\Properties\Dates\BirthdateAware`
 
@@ -465,7 +465,7 @@ ___
 
 
 ___
-`\DateTime` Date of when this component, entity or resource was created
+`\DateTimeInterface` Date of when this component, entity or resource was created
 
 *Interface*: `Aedart\Contracts\Support\Properties\Dates\CreatedAtAware`
 
@@ -539,7 +539,7 @@ ___
 
 
 ___
-`\DateTime` Date of event
+`\DateTimeInterface` Date of event
 
 *Interface*: `Aedart\Contracts\Support\Properties\Dates\DateAware`
 
@@ -566,7 +566,7 @@ ___
 
 
 ___
-`\DateTime` Date of when person, animal of something has died
+`\DateTimeInterface` Date of when person, animal of something has died
 
 *Interface*: `Aedart\Contracts\Support\Properties\Dates\DeceasedAtAware`
 
@@ -593,7 +593,7 @@ ___
 
 
 ___
-`\DateTime` Date of when this component, entity or resource was deleted
+`\DateTimeInterface` Date of when this component, entity or resource was deleted
 
 *Interface*: `Aedart\Contracts\Support\Properties\Dates\DeletedAtAware`
 
@@ -620,7 +620,7 @@ ___
 
 
 ___
-`\DateTime` Date of delivery
+`\DateTimeInterface` Date of delivery
 
 *Interface*: `Aedart\Contracts\Support\Properties\Dates\DeliveredAtAware`
 
@@ -658,7 +658,7 @@ ___
 
 
 ___
-`\DateTime` Date of planned delivery
+`\DateTimeInterface` Date of planned delivery
 
 *Interface*: `Aedart\Contracts\Support\Properties\Dates\DeliveryDateAware`
 
@@ -895,7 +895,7 @@ ___
 
 
 ___
-`\DateTime` Date for when some kind of event ends
+`\DateTimeInterface` Date for when some kind of event ends
 
 *Interface*: `Aedart\Contracts\Support\Properties\Dates\EndDateAware`
 
@@ -971,7 +971,7 @@ ___
 
 
 ___
-`\DateTime` Date of when this component, entity or resource is going to expire
+`\DateTimeInterface` Date of when this component, entity or resource is going to expire
 
 *Interface*: `Aedart\Contracts\Support\Properties\Dates\ExpiresAtAware`
 
@@ -2026,7 +2026,7 @@ ___
 
 
 ___
-`\DateTime` Date of when this component, entity or something was produced
+`\DateTimeInterface` Date of when this component, entity or something was produced
 
 *Interface*: `Aedart\Contracts\Support\Properties\Dates\ProducedAtAware`
 
@@ -2053,7 +2053,7 @@ ___
 
 
 ___
-`\DateTime` Date of planned production
+`\DateTimeInterface` Date of planned production
 
 *Interface*: `Aedart\Contracts\Support\Properties\Dates\ProductionDateAware`
 
@@ -2091,7 +2091,7 @@ ___
 
 
 ___
-`\DateTime` Date of planned purchase
+`\DateTimeInterface` Date of planned purchase
 
 *Interface*: `Aedart\Contracts\Support\Properties\Dates\PurchaseDateAware`
 
@@ -2118,7 +2118,7 @@ ___
 
 
 ___
-`\DateTime` Date of when this component, entity or resource was purchased
+`\DateTimeInterface` Date of when this component, entity or resource was purchased
 
 *Interface*: `Aedart\Contracts\Support\Properties\Dates\PurchasedAtAware`
 
@@ -2273,7 +2273,7 @@ ___
 
 
 ___
-`\DateTime` Date of when this component, entity or something was released
+`\DateTimeInterface` Date of when this component, entity or something was released
 
 *Interface*: `Aedart\Contracts\Support\Properties\Dates\ReleasedAtAware`
 
@@ -2300,7 +2300,7 @@ ___
 
 
 ___
-`\DateTime` Date of planned release
+`\DateTimeInterface` Date of planned release
 
 *Interface*: `Aedart\Contracts\Support\Properties\Dates\ReleaseDateAware`
 
@@ -2456,7 +2456,7 @@ ___
 
 
 ___
-`\DateTime` Start date of event
+`\DateTimeInterface` Start date of event
 
 *Interface*: `Aedart\Contracts\Support\Properties\Dates\StartDateAware`
 
@@ -2711,7 +2711,7 @@ ___
 
 
 ___
-`\DateTime` Date of when this component, entity or resource was updated
+`\DateTimeInterface` Date of when this component, entity or resource was updated
 
 *Interface*: `Aedart\Contracts\Support\Properties\Dates\UpdatedAtAware`
 

--- a/packages/Contracts/src/Support/Properties/Dates/AnniversaryAware.php
+++ b/packages/Contracts/src/Support/Properties/Dates/AnniversaryAware.php
@@ -5,7 +5,7 @@ namespace Aedart\Contracts\Support\Properties\Dates;
 /**
  * Anniversary Aware
  *
- * Component is aware of \DateTime "anniversary"
+ * Component is aware of \DateTimeInterface "anniversary"
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Contracts\Support\Properties\Dates
@@ -15,11 +15,11 @@ interface AnniversaryAware
     /**
      * Set anniversary
      *
-     * @param \DateTime|null $anniversary Date of anniversary
+     * @param \DateTimeInterface|null $anniversary Date of anniversary
      *
      * @return self
      */
-    public function setAnniversary(\DateTime|null $anniversary): static;
+    public function setAnniversary(\DateTimeInterface|null $anniversary): static;
 
     /**
      * Get anniversary
@@ -29,9 +29,9 @@ interface AnniversaryAware
      *
      * @see getDefaultAnniversary()
      *
-     * @return \DateTime|null anniversary or null if no anniversary has been set
+     * @return \DateTimeInterface|null anniversary or null if no anniversary has been set
      */
-    public function getAnniversary(): \DateTime|null;
+    public function getAnniversary(): \DateTimeInterface|null;
 
     /**
      * Check if anniversary has been set
@@ -43,7 +43,7 @@ interface AnniversaryAware
     /**
      * Get a default anniversary value, if any is available
      *
-     * @return \DateTime|null Default anniversary value or null if no default value is available
+     * @return \DateTimeInterface|null Default anniversary value or null if no default value is available
      */
-    public function getDefaultAnniversary(): \DateTime|null;
+    public function getDefaultAnniversary(): \DateTimeInterface|null;
 }

--- a/packages/Contracts/src/Support/Properties/Dates/BirthdateAware.php
+++ b/packages/Contracts/src/Support/Properties/Dates/BirthdateAware.php
@@ -5,7 +5,7 @@ namespace Aedart\Contracts\Support\Properties\Dates;
 /**
  * Birthdate Aware
  *
- * Component is aware of \DateTime "birthdate"
+ * Component is aware of \DateTimeInterface "birthdate"
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Contracts\Support\Properties\Dates
@@ -15,11 +15,11 @@ interface BirthdateAware
     /**
      * Set birthdate
      *
-     * @param \DateTime|null $date Date of birth
+     * @param \DateTimeInterface|null $date Date of birth
      *
      * @return self
      */
-    public function setBirthdate(\DateTime|null $date): static;
+    public function setBirthdate(\DateTimeInterface|null $date): static;
 
     /**
      * Get birthdate
@@ -29,9 +29,9 @@ interface BirthdateAware
      *
      * @see getDefaultBirthdate()
      *
-     * @return \DateTime|null birthdate or null if no birthdate has been set
+     * @return \DateTimeInterface|null birthdate or null if no birthdate has been set
      */
-    public function getBirthdate(): \DateTime|null;
+    public function getBirthdate(): \DateTimeInterface|null;
 
     /**
      * Check if birthdate has been set
@@ -43,7 +43,7 @@ interface BirthdateAware
     /**
      * Get a default birthdate value, if any is available
      *
-     * @return \DateTime|null Default birthdate value or null if no default value is available
+     * @return \DateTimeInterface|null Default birthdate value or null if no default value is available
      */
-    public function getDefaultBirthdate(): \DateTime|null;
+    public function getDefaultBirthdate(): \DateTimeInterface|null;
 }

--- a/packages/Contracts/src/Support/Properties/Dates/CreatedAtAware.php
+++ b/packages/Contracts/src/Support/Properties/Dates/CreatedAtAware.php
@@ -5,7 +5,7 @@ namespace Aedart\Contracts\Support\Properties\Dates;
 /**
  * Created at Aware
  *
- * Component is aware of \DateTime "created at"
+ * Component is aware of \DateTimeInterface "created at"
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Contracts\Support\Properties\Dates
@@ -15,11 +15,11 @@ interface CreatedAtAware
     /**
      * Set created at
      *
-     * @param \DateTime|null $date Date of when this component, entity or resource was created
+     * @param \DateTimeInterface|null $date Date of when this component, entity or resource was created
      *
      * @return self
      */
-    public function setCreatedAt(\DateTime|null $date): static;
+    public function setCreatedAt(\DateTimeInterface|null $date): static;
 
     /**
      * Get created at
@@ -29,9 +29,9 @@ interface CreatedAtAware
      *
      * @see getDefaultCreatedAt()
      *
-     * @return \DateTime|null created at or null if no created at has been set
+     * @return \DateTimeInterface|null created at or null if no created at has been set
      */
-    public function getCreatedAt(): \DateTime|null;
+    public function getCreatedAt(): \DateTimeInterface|null;
 
     /**
      * Check if created at has been set
@@ -43,7 +43,7 @@ interface CreatedAtAware
     /**
      * Get a default created at value, if any is available
      *
-     * @return \DateTime|null Default created at value or null if no default value is available
+     * @return \DateTimeInterface|null Default created at value or null if no default value is available
      */
-    public function getDefaultCreatedAt(): \DateTime|null;
+    public function getDefaultCreatedAt(): \DateTimeInterface|null;
 }

--- a/packages/Contracts/src/Support/Properties/Dates/DateAware.php
+++ b/packages/Contracts/src/Support/Properties/Dates/DateAware.php
@@ -5,7 +5,7 @@ namespace Aedart\Contracts\Support\Properties\Dates;
 /**
  * Date Aware
  *
- * Component is aware of \DateTime "date"
+ * Component is aware of \DateTimeInterface "date"
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Contracts\Support\Properties\Dates
@@ -15,11 +15,11 @@ interface DateAware
     /**
      * Set date
      *
-     * @param \DateTime|null $date Date of event
+     * @param \DateTimeInterface|null $date Date of event
      *
      * @return self
      */
-    public function setDate(\DateTime|null $date): static;
+    public function setDate(\DateTimeInterface|null $date): static;
 
     /**
      * Get date
@@ -29,9 +29,9 @@ interface DateAware
      *
      * @see getDefaultDate()
      *
-     * @return \DateTime|null date or null if no date has been set
+     * @return \DateTimeInterface|null date or null if no date has been set
      */
-    public function getDate(): \DateTime|null;
+    public function getDate(): \DateTimeInterface|null;
 
     /**
      * Check if date has been set
@@ -43,7 +43,7 @@ interface DateAware
     /**
      * Get a default date value, if any is available
      *
-     * @return \DateTime|null Default date value or null if no default value is available
+     * @return \DateTimeInterface|null Default date value or null if no default value is available
      */
-    public function getDefaultDate(): \DateTime|null;
+    public function getDefaultDate(): \DateTimeInterface|null;
 }

--- a/packages/Contracts/src/Support/Properties/Dates/DeceasedAtAware.php
+++ b/packages/Contracts/src/Support/Properties/Dates/DeceasedAtAware.php
@@ -5,7 +5,7 @@ namespace Aedart\Contracts\Support\Properties\Dates;
 /**
  * Deceased at Aware
  *
- * Component is aware of \DateTime "deceased at"
+ * Component is aware of \DateTimeInterface "deceased at"
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Contracts\Support\Properties\Dates
@@ -15,11 +15,11 @@ interface DeceasedAtAware
     /**
      * Set deceased at
      *
-     * @param \DateTime|null $date Date of when person, animal of something has died
+     * @param \DateTimeInterface|null $date Date of when person, animal of something has died
      *
      * @return self
      */
-    public function setDeceasedAt(\DateTime|null $date): static;
+    public function setDeceasedAt(\DateTimeInterface|null $date): static;
 
     /**
      * Get deceased at
@@ -29,9 +29,9 @@ interface DeceasedAtAware
      *
      * @see getDefaultDeceasedAt()
      *
-     * @return \DateTime|null deceased at or null if no deceased at has been set
+     * @return \DateTimeInterface|null deceased at or null if no deceased at has been set
      */
-    public function getDeceasedAt(): \DateTime|null;
+    public function getDeceasedAt(): \DateTimeInterface|null;
 
     /**
      * Check if deceased at has been set
@@ -43,7 +43,7 @@ interface DeceasedAtAware
     /**
      * Get a default deceased at value, if any is available
      *
-     * @return \DateTime|null Default deceased at value or null if no default value is available
+     * @return \DateTimeInterface|null Default deceased at value or null if no default value is available
      */
-    public function getDefaultDeceasedAt(): \DateTime|null;
+    public function getDefaultDeceasedAt(): \DateTimeInterface|null;
 }

--- a/packages/Contracts/src/Support/Properties/Dates/DeletedAtAware.php
+++ b/packages/Contracts/src/Support/Properties/Dates/DeletedAtAware.php
@@ -5,7 +5,7 @@ namespace Aedart\Contracts\Support\Properties\Dates;
 /**
  * Deleted at Aware
  *
- * Component is aware of \DateTime "deleted at"
+ * Component is aware of \DateTimeInterface "deleted at"
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Contracts\Support\Properties\Dates
@@ -15,11 +15,11 @@ interface DeletedAtAware
     /**
      * Set deleted at
      *
-     * @param \DateTime|null $date Date of when this component, entity or resource was deleted
+     * @param \DateTimeInterface|null $date Date of when this component, entity or resource was deleted
      *
      * @return self
      */
-    public function setDeletedAt(\DateTime|null $date): static;
+    public function setDeletedAt(\DateTimeInterface|null $date): static;
 
     /**
      * Get deleted at
@@ -29,9 +29,9 @@ interface DeletedAtAware
      *
      * @see getDefaultDeletedAt()
      *
-     * @return \DateTime|null deleted at or null if no deleted at has been set
+     * @return \DateTimeInterface|null deleted at or null if no deleted at has been set
      */
-    public function getDeletedAt(): \DateTime|null;
+    public function getDeletedAt(): \DateTimeInterface|null;
 
     /**
      * Check if deleted at has been set
@@ -43,7 +43,7 @@ interface DeletedAtAware
     /**
      * Get a default deleted at value, if any is available
      *
-     * @return \DateTime|null Default deleted at value or null if no default value is available
+     * @return \DateTimeInterface|null Default deleted at value or null if no default value is available
      */
-    public function getDefaultDeletedAt(): \DateTime|null;
+    public function getDefaultDeletedAt(): \DateTimeInterface|null;
 }

--- a/packages/Contracts/src/Support/Properties/Dates/DeliveredAtAware.php
+++ b/packages/Contracts/src/Support/Properties/Dates/DeliveredAtAware.php
@@ -5,7 +5,7 @@ namespace Aedart\Contracts\Support\Properties\Dates;
 /**
  * Delivered at Aware
  *
- * Component is aware of \DateTime "delivered at"
+ * Component is aware of \DateTimeInterface "delivered at"
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Contracts\Support\Properties\Dates
@@ -15,11 +15,11 @@ interface DeliveredAtAware
     /**
      * Set delivered at
      *
-     * @param \DateTime|null $date Date of delivery
+     * @param \DateTimeInterface|null $date Date of delivery
      *
      * @return self
      */
-    public function setDeliveredAt(\DateTime|null $date): static;
+    public function setDeliveredAt(\DateTimeInterface|null $date): static;
 
     /**
      * Get delivered at
@@ -29,9 +29,9 @@ interface DeliveredAtAware
      *
      * @see getDefaultDeliveredAt()
      *
-     * @return \DateTime|null delivered at or null if no delivered at has been set
+     * @return \DateTimeInterface|null delivered at or null if no delivered at has been set
      */
-    public function getDeliveredAt(): \DateTime|null;
+    public function getDeliveredAt(): \DateTimeInterface|null;
 
     /**
      * Check if delivered at has been set
@@ -43,7 +43,7 @@ interface DeliveredAtAware
     /**
      * Get a default delivered at value, if any is available
      *
-     * @return \DateTime|null Default delivered at value or null if no default value is available
+     * @return \DateTimeInterface|null Default delivered at value or null if no default value is available
      */
-    public function getDefaultDeliveredAt(): \DateTime|null;
+    public function getDefaultDeliveredAt(): \DateTimeInterface|null;
 }

--- a/packages/Contracts/src/Support/Properties/Dates/DeliveryDateAware.php
+++ b/packages/Contracts/src/Support/Properties/Dates/DeliveryDateAware.php
@@ -5,7 +5,7 @@ namespace Aedart\Contracts\Support\Properties\Dates;
 /**
  * Delivery date Aware
  *
- * Component is aware of \DateTime "delivery date"
+ * Component is aware of \DateTimeInterface "delivery date"
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Contracts\Support\Properties\Dates
@@ -15,11 +15,11 @@ interface DeliveryDateAware
     /**
      * Set delivery date
      *
-     * @param \DateTime|null $date Date of planned delivery
+     * @param \DateTimeInterface|null $date Date of planned delivery
      *
      * @return self
      */
-    public function setDeliveryDate(\DateTime|null $date): static;
+    public function setDeliveryDate(\DateTimeInterface|null $date): static;
 
     /**
      * Get delivery date
@@ -29,9 +29,9 @@ interface DeliveryDateAware
      *
      * @see getDefaultDeliveryDate()
      *
-     * @return \DateTime|null delivery date or null if no delivery date has been set
+     * @return \DateTimeInterface|null delivery date or null if no delivery date has been set
      */
-    public function getDeliveryDate(): \DateTime|null;
+    public function getDeliveryDate(): \DateTimeInterface|null;
 
     /**
      * Check if delivery date has been set
@@ -43,7 +43,7 @@ interface DeliveryDateAware
     /**
      * Get a default delivery date value, if any is available
      *
-     * @return \DateTime|null Default delivery date value or null if no default value is available
+     * @return \DateTimeInterface|null Default delivery date value or null if no default value is available
      */
-    public function getDefaultDeliveryDate(): \DateTime|null;
+    public function getDefaultDeliveryDate(): \DateTimeInterface|null;
 }

--- a/packages/Contracts/src/Support/Properties/Dates/EndDateAware.php
+++ b/packages/Contracts/src/Support/Properties/Dates/EndDateAware.php
@@ -5,7 +5,7 @@ namespace Aedart\Contracts\Support\Properties\Dates;
 /**
  * End date Aware
  *
- * Component is aware of \DateTime "end date"
+ * Component is aware of \DateTimeInterface "end date"
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Contracts\Support\Properties\Dates
@@ -15,11 +15,11 @@ interface EndDateAware
     /**
      * Set end date
      *
-     * @param \DateTime|null $date Date for when some kind of event ends
+     * @param \DateTimeInterface|null $date Date for when some kind of event ends
      *
      * @return self
      */
-    public function setEndDate(\DateTime|null $date): static;
+    public function setEndDate(\DateTimeInterface|null $date): static;
 
     /**
      * Get end date
@@ -29,9 +29,9 @@ interface EndDateAware
      *
      * @see getDefaultEndDate()
      *
-     * @return \DateTime|null end date or null if no end date has been set
+     * @return \DateTimeInterface|null end date or null if no end date has been set
      */
-    public function getEndDate(): \DateTime|null;
+    public function getEndDate(): \DateTimeInterface|null;
 
     /**
      * Check if end date has been set
@@ -43,7 +43,7 @@ interface EndDateAware
     /**
      * Get a default end date value, if any is available
      *
-     * @return \DateTime|null Default end date value or null if no default value is available
+     * @return \DateTimeInterface|null Default end date value or null if no default value is available
      */
-    public function getDefaultEndDate(): \DateTime|null;
+    public function getDefaultEndDate(): \DateTimeInterface|null;
 }

--- a/packages/Contracts/src/Support/Properties/Dates/ExpiresAtAware.php
+++ b/packages/Contracts/src/Support/Properties/Dates/ExpiresAtAware.php
@@ -5,7 +5,7 @@ namespace Aedart\Contracts\Support\Properties\Dates;
 /**
  * Expires at Aware
  *
- * Component is aware of \DateTime "expires at"
+ * Component is aware of \DateTimeInterface "expires at"
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Contracts\Support\Properties\Dates
@@ -15,11 +15,11 @@ interface ExpiresAtAware
     /**
      * Set expires at
      *
-     * @param \DateTime|null $date Date of when this component, entity or resource is going to expire
+     * @param \DateTimeInterface|null $date Date of when this component, entity or resource is going to expire
      *
      * @return self
      */
-    public function setExpiresAt(\DateTime|null $date): static;
+    public function setExpiresAt(\DateTimeInterface|null $date): static;
 
     /**
      * Get expires at
@@ -29,9 +29,9 @@ interface ExpiresAtAware
      *
      * @see getDefaultExpiresAt()
      *
-     * @return \DateTime|null expires at or null if no expires at has been set
+     * @return \DateTimeInterface|null expires at or null if no expires at has been set
      */
-    public function getExpiresAt(): \DateTime|null;
+    public function getExpiresAt(): \DateTimeInterface|null;
 
     /**
      * Check if expires at has been set
@@ -43,7 +43,7 @@ interface ExpiresAtAware
     /**
      * Get a default expires at value, if any is available
      *
-     * @return \DateTime|null Default expires at value or null if no default value is available
+     * @return \DateTimeInterface|null Default expires at value or null if no default value is available
      */
-    public function getDefaultExpiresAt(): \DateTime|null;
+    public function getDefaultExpiresAt(): \DateTimeInterface|null;
 }

--- a/packages/Contracts/src/Support/Properties/Dates/ProducedAtAware.php
+++ b/packages/Contracts/src/Support/Properties/Dates/ProducedAtAware.php
@@ -5,7 +5,7 @@ namespace Aedart\Contracts\Support\Properties\Dates;
 /**
  * Produced at Aware
  *
- * Component is aware of \DateTime "produced at"
+ * Component is aware of \DateTimeInterface "produced at"
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Contracts\Support\Properties\Dates
@@ -15,11 +15,11 @@ interface ProducedAtAware
     /**
      * Set produced at
      *
-     * @param \DateTime|null $date Date of when this component, entity or something was produced
+     * @param \DateTimeInterface|null $date Date of when this component, entity or something was produced
      *
      * @return self
      */
-    public function setProducedAt(\DateTime|null $date): static;
+    public function setProducedAt(\DateTimeInterface|null $date): static;
 
     /**
      * Get produced at
@@ -29,9 +29,9 @@ interface ProducedAtAware
      *
      * @see getDefaultProducedAt()
      *
-     * @return \DateTime|null produced at or null if no produced at has been set
+     * @return \DateTimeInterface|null produced at or null if no produced at has been set
      */
-    public function getProducedAt(): \DateTime|null;
+    public function getProducedAt(): \DateTimeInterface|null;
 
     /**
      * Check if produced at has been set
@@ -43,7 +43,7 @@ interface ProducedAtAware
     /**
      * Get a default produced at value, if any is available
      *
-     * @return \DateTime|null Default produced at value or null if no default value is available
+     * @return \DateTimeInterface|null Default produced at value or null if no default value is available
      */
-    public function getDefaultProducedAt(): \DateTime|null;
+    public function getDefaultProducedAt(): \DateTimeInterface|null;
 }

--- a/packages/Contracts/src/Support/Properties/Dates/ProductionDateAware.php
+++ b/packages/Contracts/src/Support/Properties/Dates/ProductionDateAware.php
@@ -5,7 +5,7 @@ namespace Aedart\Contracts\Support\Properties\Dates;
 /**
  * Production date Aware
  *
- * Component is aware of \DateTime "production date"
+ * Component is aware of \DateTimeInterface "production date"
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Contracts\Support\Properties\Dates
@@ -15,11 +15,11 @@ interface ProductionDateAware
     /**
      * Set production date
      *
-     * @param \DateTime|null $date Date of planned production
+     * @param \DateTimeInterface|null $date Date of planned production
      *
      * @return self
      */
-    public function setProductionDate(\DateTime|null $date): static;
+    public function setProductionDate(\DateTimeInterface|null $date): static;
 
     /**
      * Get production date
@@ -29,9 +29,9 @@ interface ProductionDateAware
      *
      * @see getDefaultProductionDate()
      *
-     * @return \DateTime|null production date or null if no production date has been set
+     * @return \DateTimeInterface|null production date or null if no production date has been set
      */
-    public function getProductionDate(): \DateTime|null;
+    public function getProductionDate(): \DateTimeInterface|null;
 
     /**
      * Check if production date has been set
@@ -43,7 +43,7 @@ interface ProductionDateAware
     /**
      * Get a default production date value, if any is available
      *
-     * @return \DateTime|null Default production date value or null if no default value is available
+     * @return \DateTimeInterface|null Default production date value or null if no default value is available
      */
-    public function getDefaultProductionDate(): \DateTime|null;
+    public function getDefaultProductionDate(): \DateTimeInterface|null;
 }

--- a/packages/Contracts/src/Support/Properties/Dates/PurchaseDateAware.php
+++ b/packages/Contracts/src/Support/Properties/Dates/PurchaseDateAware.php
@@ -5,7 +5,7 @@ namespace Aedart\Contracts\Support\Properties\Dates;
 /**
  * Purchase date Aware
  *
- * Component is aware of \DateTime "purchase date"
+ * Component is aware of \DateTimeInterface "purchase date"
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Contracts\Support\Properties\Dates
@@ -15,11 +15,11 @@ interface PurchaseDateAware
     /**
      * Set purchase date
      *
-     * @param \DateTime|null $date Date of planned purchase
+     * @param \DateTimeInterface|null $date Date of planned purchase
      *
      * @return self
      */
-    public function setPurchaseDate(\DateTime|null $date): static;
+    public function setPurchaseDate(\DateTimeInterface|null $date): static;
 
     /**
      * Get purchase date
@@ -29,9 +29,9 @@ interface PurchaseDateAware
      *
      * @see getDefaultPurchaseDate()
      *
-     * @return \DateTime|null purchase date or null if no purchase date has been set
+     * @return \DateTimeInterface|null purchase date or null if no purchase date has been set
      */
-    public function getPurchaseDate(): \DateTime|null;
+    public function getPurchaseDate(): \DateTimeInterface|null;
 
     /**
      * Check if purchase date has been set
@@ -43,7 +43,7 @@ interface PurchaseDateAware
     /**
      * Get a default purchase date value, if any is available
      *
-     * @return \DateTime|null Default purchase date value or null if no default value is available
+     * @return \DateTimeInterface|null Default purchase date value or null if no default value is available
      */
-    public function getDefaultPurchaseDate(): \DateTime|null;
+    public function getDefaultPurchaseDate(): \DateTimeInterface|null;
 }

--- a/packages/Contracts/src/Support/Properties/Dates/PurchasedAtAware.php
+++ b/packages/Contracts/src/Support/Properties/Dates/PurchasedAtAware.php
@@ -5,7 +5,7 @@ namespace Aedart\Contracts\Support\Properties\Dates;
 /**
  * Purchased at Aware
  *
- * Component is aware of \DateTime "purchased at"
+ * Component is aware of \DateTimeInterface "purchased at"
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Contracts\Support\Properties\Dates
@@ -15,11 +15,11 @@ interface PurchasedAtAware
     /**
      * Set purchased at
      *
-     * @param \DateTime|null $date Date of when this component, entity or resource was purchased
+     * @param \DateTimeInterface|null $date Date of when this component, entity or resource was purchased
      *
      * @return self
      */
-    public function setPurchasedAt(\DateTime|null $date): static;
+    public function setPurchasedAt(\DateTimeInterface|null $date): static;
 
     /**
      * Get purchased at
@@ -29,9 +29,9 @@ interface PurchasedAtAware
      *
      * @see getDefaultPurchasedAt()
      *
-     * @return \DateTime|null purchased at or null if no purchased at has been set
+     * @return \DateTimeInterface|null purchased at or null if no purchased at has been set
      */
-    public function getPurchasedAt(): \DateTime|null;
+    public function getPurchasedAt(): \DateTimeInterface|null;
 
     /**
      * Check if purchased at has been set
@@ -43,7 +43,7 @@ interface PurchasedAtAware
     /**
      * Get a default purchased at value, if any is available
      *
-     * @return \DateTime|null Default purchased at value or null if no default value is available
+     * @return \DateTimeInterface|null Default purchased at value or null if no default value is available
      */
-    public function getDefaultPurchasedAt(): \DateTime|null;
+    public function getDefaultPurchasedAt(): \DateTimeInterface|null;
 }

--- a/packages/Contracts/src/Support/Properties/Dates/ReleaseDateAware.php
+++ b/packages/Contracts/src/Support/Properties/Dates/ReleaseDateAware.php
@@ -5,7 +5,7 @@ namespace Aedart\Contracts\Support\Properties\Dates;
 /**
  * Release date Aware
  *
- * Component is aware of \DateTime "release date"
+ * Component is aware of \DateTimeInterface "release date"
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Contracts\Support\Properties\Dates
@@ -15,11 +15,11 @@ interface ReleaseDateAware
     /**
      * Set release date
      *
-     * @param \DateTime|null $date Date of planned release
+     * @param \DateTimeInterface|null $date Date of planned release
      *
      * @return self
      */
-    public function setReleaseDate(\DateTime|null $date): static;
+    public function setReleaseDate(\DateTimeInterface|null $date): static;
 
     /**
      * Get release date
@@ -29,9 +29,9 @@ interface ReleaseDateAware
      *
      * @see getDefaultReleaseDate()
      *
-     * @return \DateTime|null release date or null if no release date has been set
+     * @return \DateTimeInterface|null release date or null if no release date has been set
      */
-    public function getReleaseDate(): \DateTime|null;
+    public function getReleaseDate(): \DateTimeInterface|null;
 
     /**
      * Check if release date has been set
@@ -43,7 +43,7 @@ interface ReleaseDateAware
     /**
      * Get a default release date value, if any is available
      *
-     * @return \DateTime|null Default release date value or null if no default value is available
+     * @return \DateTimeInterface|null Default release date value or null if no default value is available
      */
-    public function getDefaultReleaseDate(): \DateTime|null;
+    public function getDefaultReleaseDate(): \DateTimeInterface|null;
 }

--- a/packages/Contracts/src/Support/Properties/Dates/ReleasedAtAware.php
+++ b/packages/Contracts/src/Support/Properties/Dates/ReleasedAtAware.php
@@ -5,7 +5,7 @@ namespace Aedart\Contracts\Support\Properties\Dates;
 /**
  * Released at Aware
  *
- * Component is aware of \DateTime "released at"
+ * Component is aware of \DateTimeInterface "released at"
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Contracts\Support\Properties\Dates
@@ -15,11 +15,11 @@ interface ReleasedAtAware
     /**
      * Set released at
      *
-     * @param \DateTime|null $date Date of when this component, entity or something was released
+     * @param \DateTimeInterface|null $date Date of when this component, entity or something was released
      *
      * @return self
      */
-    public function setReleasedAt(\DateTime|null $date): static;
+    public function setReleasedAt(\DateTimeInterface|null $date): static;
 
     /**
      * Get released at
@@ -29,9 +29,9 @@ interface ReleasedAtAware
      *
      * @see getDefaultReleasedAt()
      *
-     * @return \DateTime|null released at or null if no released at has been set
+     * @return \DateTimeInterface|null released at or null if no released at has been set
      */
-    public function getReleasedAt(): \DateTime|null;
+    public function getReleasedAt(): \DateTimeInterface|null;
 
     /**
      * Check if released at has been set
@@ -43,7 +43,7 @@ interface ReleasedAtAware
     /**
      * Get a default released at value, if any is available
      *
-     * @return \DateTime|null Default released at value or null if no default value is available
+     * @return \DateTimeInterface|null Default released at value or null if no default value is available
      */
-    public function getDefaultReleasedAt(): \DateTime|null;
+    public function getDefaultReleasedAt(): \DateTimeInterface|null;
 }

--- a/packages/Contracts/src/Support/Properties/Dates/StartDateAware.php
+++ b/packages/Contracts/src/Support/Properties/Dates/StartDateAware.php
@@ -5,7 +5,7 @@ namespace Aedart\Contracts\Support\Properties\Dates;
 /**
  * Start date Aware
  *
- * Component is aware of \DateTime "start date"
+ * Component is aware of \DateTimeInterface "start date"
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Contracts\Support\Properties\Dates
@@ -15,11 +15,11 @@ interface StartDateAware
     /**
      * Set start date
      *
-     * @param \DateTime|null $date Start date of event
+     * @param \DateTimeInterface|null $date Start date of event
      *
      * @return self
      */
-    public function setStartDate(\DateTime|null $date): static;
+    public function setStartDate(\DateTimeInterface|null $date): static;
 
     /**
      * Get start date
@@ -29,9 +29,9 @@ interface StartDateAware
      *
      * @see getDefaultStartDate()
      *
-     * @return \DateTime|null start date or null if no start date has been set
+     * @return \DateTimeInterface|null start date or null if no start date has been set
      */
-    public function getStartDate(): \DateTime|null;
+    public function getStartDate(): \DateTimeInterface|null;
 
     /**
      * Check if start date has been set
@@ -43,7 +43,7 @@ interface StartDateAware
     /**
      * Get a default start date value, if any is available
      *
-     * @return \DateTime|null Default start date value or null if no default value is available
+     * @return \DateTimeInterface|null Default start date value or null if no default value is available
      */
-    public function getDefaultStartDate(): \DateTime|null;
+    public function getDefaultStartDate(): \DateTimeInterface|null;
 }

--- a/packages/Contracts/src/Support/Properties/Dates/UpdatedAtAware.php
+++ b/packages/Contracts/src/Support/Properties/Dates/UpdatedAtAware.php
@@ -5,7 +5,7 @@ namespace Aedart\Contracts\Support\Properties\Dates;
 /**
  * Updated at Aware
  *
- * Component is aware of \DateTime "updated at"
+ * Component is aware of \DateTimeInterface "updated at"
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Contracts\Support\Properties\Dates
@@ -15,11 +15,11 @@ interface UpdatedAtAware
     /**
      * Set updated at
      *
-     * @param \DateTime|null $date Date of when this component, entity or resource was updated
+     * @param \DateTimeInterface|null $date Date of when this component, entity or resource was updated
      *
      * @return self
      */
-    public function setUpdatedAt(\DateTime|null $date): static;
+    public function setUpdatedAt(\DateTimeInterface|null $date): static;
 
     /**
      * Get updated at
@@ -29,9 +29,9 @@ interface UpdatedAtAware
      *
      * @see getDefaultUpdatedAt()
      *
-     * @return \DateTime|null updated at or null if no updated at has been set
+     * @return \DateTimeInterface|null updated at or null if no updated at has been set
      */
-    public function getUpdatedAt(): \DateTime|null;
+    public function getUpdatedAt(): \DateTimeInterface|null;
 
     /**
      * Check if updated at has been set
@@ -43,7 +43,7 @@ interface UpdatedAtAware
     /**
      * Get a default updated at value, if any is available
      *
-     * @return \DateTime|null Default updated at value or null if no default value is available
+     * @return \DateTimeInterface|null Default updated at value or null if no default value is available
      */
-    public function getDefaultUpdatedAt(): \DateTime|null;
+    public function getDefaultUpdatedAt(): \DateTimeInterface|null;
 }

--- a/packages/Contracts/src/Utils/DataTypes.php
+++ b/packages/Contracts/src/Utils/DataTypes.php
@@ -113,5 +113,5 @@ interface DataTypes
     /**
      * Date Time type
      */
-    public const DATE_TIME_TYPE = '\DateTime';
+    public const DATE_TIME_TYPE = '\DateTimeInterface';
 }

--- a/packages/Support/src/Properties/Dates/AnniversaryTrait.php
+++ b/packages/Support/src/Properties/Dates/AnniversaryTrait.php
@@ -15,18 +15,18 @@ trait AnniversaryTrait
     /**
      * Date of anniversary
      *
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
-    protected \DateTime|null $anniversary = null;
+    protected \DateTimeInterface|null $anniversary = null;
 
     /**
      * Set anniversary
      *
-     * @param \DateTime|null $anniversary Date of anniversary
+     * @param \DateTimeInterface|null $anniversary Date of anniversary
      *
      * @return self
      */
-    public function setAnniversary(\DateTime|null $anniversary): static
+    public function setAnniversary(\DateTimeInterface|null $anniversary): static
     {
         $this->anniversary = $anniversary;
 
@@ -41,9 +41,9 @@ trait AnniversaryTrait
      *
      * @see getDefaultAnniversary()
      *
-     * @return \DateTime|null anniversary or null if no anniversary has been set
+     * @return \DateTimeInterface|null anniversary or null if no anniversary has been set
      */
-    public function getAnniversary(): \DateTime|null
+    public function getAnniversary(): \DateTimeInterface|null
     {
         if (!$this->hasAnniversary()) {
             $this->setAnniversary($this->getDefaultAnniversary());
@@ -64,9 +64,9 @@ trait AnniversaryTrait
     /**
      * Get a default anniversary value, if any is available
      *
-     * @return \DateTime|null Default anniversary value or null if no default value is available
+     * @return \DateTimeInterface|null Default anniversary value or null if no default value is available
      */
-    public function getDefaultAnniversary(): \DateTime|null
+    public function getDefaultAnniversary(): \DateTimeInterface|null
     {
         return null;
     }

--- a/packages/Support/src/Properties/Dates/BirthdateTrait.php
+++ b/packages/Support/src/Properties/Dates/BirthdateTrait.php
@@ -15,18 +15,18 @@ trait BirthdateTrait
     /**
      * Date of birth
      *
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
-    protected \DateTime|null $birthdate = null;
+    protected \DateTimeInterface|null $birthdate = null;
 
     /**
      * Set birthdate
      *
-     * @param \DateTime|null $date Date of birth
+     * @param \DateTimeInterface|null $date Date of birth
      *
      * @return self
      */
-    public function setBirthdate(\DateTime|null $date): static
+    public function setBirthdate(\DateTimeInterface|null $date): static
     {
         $this->birthdate = $date;
 
@@ -41,9 +41,9 @@ trait BirthdateTrait
      *
      * @see getDefaultBirthdate()
      *
-     * @return \DateTime|null birthdate or null if no birthdate has been set
+     * @return \DateTimeInterface|null birthdate or null if no birthdate has been set
      */
-    public function getBirthdate(): \DateTime|null
+    public function getBirthdate(): \DateTimeInterface|null
     {
         if (!$this->hasBirthdate()) {
             $this->setBirthdate($this->getDefaultBirthdate());
@@ -64,9 +64,9 @@ trait BirthdateTrait
     /**
      * Get a default birthdate value, if any is available
      *
-     * @return \DateTime|null Default birthdate value or null if no default value is available
+     * @return \DateTimeInterface|null Default birthdate value or null if no default value is available
      */
-    public function getDefaultBirthdate(): \DateTime|null
+    public function getDefaultBirthdate(): \DateTimeInterface|null
     {
         return null;
     }

--- a/packages/Support/src/Properties/Dates/CreatedAtTrait.php
+++ b/packages/Support/src/Properties/Dates/CreatedAtTrait.php
@@ -15,18 +15,18 @@ trait CreatedAtTrait
     /**
      * Date of when this component, entity or resource was created
      *
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
-    protected \DateTime|null $createdAt = null;
+    protected \DateTimeInterface|null $createdAt = null;
 
     /**
      * Set created at
      *
-     * @param \DateTime|null $date Date of when this component, entity or resource was created
+     * @param \DateTimeInterface|null $date Date of when this component, entity or resource was created
      *
      * @return self
      */
-    public function setCreatedAt(\DateTime|null $date): static
+    public function setCreatedAt(\DateTimeInterface|null $date): static
     {
         $this->createdAt = $date;
 
@@ -41,9 +41,9 @@ trait CreatedAtTrait
      *
      * @see getDefaultCreatedAt()
      *
-     * @return \DateTime|null created at or null if no created at has been set
+     * @return \DateTimeInterface|null created at or null if no created at has been set
      */
-    public function getCreatedAt(): \DateTime|null
+    public function getCreatedAt(): \DateTimeInterface|null
     {
         if (!$this->hasCreatedAt()) {
             $this->setCreatedAt($this->getDefaultCreatedAt());
@@ -64,9 +64,9 @@ trait CreatedAtTrait
     /**
      * Get a default created at value, if any is available
      *
-     * @return \DateTime|null Default created at value or null if no default value is available
+     * @return \DateTimeInterface|null Default created at value or null if no default value is available
      */
-    public function getDefaultCreatedAt(): \DateTime|null
+    public function getDefaultCreatedAt(): \DateTimeInterface|null
     {
         return null;
     }

--- a/packages/Support/src/Properties/Dates/DateTrait.php
+++ b/packages/Support/src/Properties/Dates/DateTrait.php
@@ -15,18 +15,18 @@ trait DateTrait
     /**
      * Date of event
      *
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
-    protected \DateTime|null $date = null;
+    protected \DateTimeInterface|null $date = null;
 
     /**
      * Set date
      *
-     * @param \DateTime|null $date Date of event
+     * @param \DateTimeInterface|null $date Date of event
      *
      * @return self
      */
-    public function setDate(\DateTime|null $date): static
+    public function setDate(\DateTimeInterface|null $date): static
     {
         $this->date = $date;
 
@@ -41,9 +41,9 @@ trait DateTrait
      *
      * @see getDefaultDate()
      *
-     * @return \DateTime|null date or null if no date has been set
+     * @return \DateTimeInterface|null date or null if no date has been set
      */
-    public function getDate(): \DateTime|null
+    public function getDate(): \DateTimeInterface|null
     {
         if (!$this->hasDate()) {
             $this->setDate($this->getDefaultDate());
@@ -64,9 +64,9 @@ trait DateTrait
     /**
      * Get a default date value, if any is available
      *
-     * @return \DateTime|null Default date value or null if no default value is available
+     * @return \DateTimeInterface|null Default date value or null if no default value is available
      */
-    public function getDefaultDate(): \DateTime|null
+    public function getDefaultDate(): \DateTimeInterface|null
     {
         return null;
     }

--- a/packages/Support/src/Properties/Dates/DeceasedAtTrait.php
+++ b/packages/Support/src/Properties/Dates/DeceasedAtTrait.php
@@ -15,18 +15,18 @@ trait DeceasedAtTrait
     /**
      * Date of when person, animal of something has died
      *
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
-    protected \DateTime|null $deceasedAt = null;
+    protected \DateTimeInterface|null $deceasedAt = null;
 
     /**
      * Set deceased at
      *
-     * @param \DateTime|null $date Date of when person, animal of something has died
+     * @param \DateTimeInterface|null $date Date of when person, animal of something has died
      *
      * @return self
      */
-    public function setDeceasedAt(\DateTime|null $date): static
+    public function setDeceasedAt(\DateTimeInterface|null $date): static
     {
         $this->deceasedAt = $date;
 
@@ -41,9 +41,9 @@ trait DeceasedAtTrait
      *
      * @see getDefaultDeceasedAt()
      *
-     * @return \DateTime|null deceased at or null if no deceased at has been set
+     * @return \DateTimeInterface|null deceased at or null if no deceased at has been set
      */
-    public function getDeceasedAt(): \DateTime|null
+    public function getDeceasedAt(): \DateTimeInterface|null
     {
         if (!$this->hasDeceasedAt()) {
             $this->setDeceasedAt($this->getDefaultDeceasedAt());
@@ -64,9 +64,9 @@ trait DeceasedAtTrait
     /**
      * Get a default deceased at value, if any is available
      *
-     * @return \DateTime|null Default deceased at value or null if no default value is available
+     * @return \DateTimeInterface|null Default deceased at value or null if no default value is available
      */
-    public function getDefaultDeceasedAt(): \DateTime|null
+    public function getDefaultDeceasedAt(): \DateTimeInterface|null
     {
         return null;
     }

--- a/packages/Support/src/Properties/Dates/DeletedAtTrait.php
+++ b/packages/Support/src/Properties/Dates/DeletedAtTrait.php
@@ -15,18 +15,18 @@ trait DeletedAtTrait
     /**
      * Date of when this component, entity or resource was deleted
      *
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
-    protected \DateTime|null $deletedAt = null;
+    protected \DateTimeInterface|null $deletedAt = null;
 
     /**
      * Set deleted at
      *
-     * @param \DateTime|null $date Date of when this component, entity or resource was deleted
+     * @param \DateTimeInterface|null $date Date of when this component, entity or resource was deleted
      *
      * @return self
      */
-    public function setDeletedAt(\DateTime|null $date): static
+    public function setDeletedAt(\DateTimeInterface|null $date): static
     {
         $this->deletedAt = $date;
 
@@ -41,9 +41,9 @@ trait DeletedAtTrait
      *
      * @see getDefaultDeletedAt()
      *
-     * @return \DateTime|null deleted at or null if no deleted at has been set
+     * @return \DateTimeInterface|null deleted at or null if no deleted at has been set
      */
-    public function getDeletedAt(): \DateTime|null
+    public function getDeletedAt(): \DateTimeInterface|null
     {
         if (!$this->hasDeletedAt()) {
             $this->setDeletedAt($this->getDefaultDeletedAt());
@@ -64,9 +64,9 @@ trait DeletedAtTrait
     /**
      * Get a default deleted at value, if any is available
      *
-     * @return \DateTime|null Default deleted at value or null if no default value is available
+     * @return \DateTimeInterface|null Default deleted at value or null if no default value is available
      */
-    public function getDefaultDeletedAt(): \DateTime|null
+    public function getDefaultDeletedAt(): \DateTimeInterface|null
     {
         return null;
     }

--- a/packages/Support/src/Properties/Dates/DeliveredAtTrait.php
+++ b/packages/Support/src/Properties/Dates/DeliveredAtTrait.php
@@ -15,18 +15,18 @@ trait DeliveredAtTrait
     /**
      * Date of delivery
      *
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
-    protected \DateTime|null $deliveredAt = null;
+    protected \DateTimeInterface|null $deliveredAt = null;
 
     /**
      * Set delivered at
      *
-     * @param \DateTime|null $date Date of delivery
+     * @param \DateTimeInterface|null $date Date of delivery
      *
      * @return self
      */
-    public function setDeliveredAt(\DateTime|null $date): static
+    public function setDeliveredAt(\DateTimeInterface|null $date): static
     {
         $this->deliveredAt = $date;
 
@@ -41,9 +41,9 @@ trait DeliveredAtTrait
      *
      * @see getDefaultDeliveredAt()
      *
-     * @return \DateTime|null delivered at or null if no delivered at has been set
+     * @return \DateTimeInterface|null delivered at or null if no delivered at has been set
      */
-    public function getDeliveredAt(): \DateTime|null
+    public function getDeliveredAt(): \DateTimeInterface|null
     {
         if (!$this->hasDeliveredAt()) {
             $this->setDeliveredAt($this->getDefaultDeliveredAt());
@@ -64,9 +64,9 @@ trait DeliveredAtTrait
     /**
      * Get a default delivered at value, if any is available
      *
-     * @return \DateTime|null Default delivered at value or null if no default value is available
+     * @return \DateTimeInterface|null Default delivered at value or null if no default value is available
      */
-    public function getDefaultDeliveredAt(): \DateTime|null
+    public function getDefaultDeliveredAt(): \DateTimeInterface|null
     {
         return null;
     }

--- a/packages/Support/src/Properties/Dates/DeliveryDateTrait.php
+++ b/packages/Support/src/Properties/Dates/DeliveryDateTrait.php
@@ -15,18 +15,18 @@ trait DeliveryDateTrait
     /**
      * Date of planned delivery
      *
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
-    protected \DateTime|null $deliveryDate = null;
+    protected \DateTimeInterface|null $deliveryDate = null;
 
     /**
      * Set delivery date
      *
-     * @param \DateTime|null $date Date of planned delivery
+     * @param \DateTimeInterface|null $date Date of planned delivery
      *
      * @return self
      */
-    public function setDeliveryDate(\DateTime|null $date): static
+    public function setDeliveryDate(\DateTimeInterface|null $date): static
     {
         $this->deliveryDate = $date;
 
@@ -41,9 +41,9 @@ trait DeliveryDateTrait
      *
      * @see getDefaultDeliveryDate()
      *
-     * @return \DateTime|null delivery date or null if no delivery date has been set
+     * @return \DateTimeInterface|null delivery date or null if no delivery date has been set
      */
-    public function getDeliveryDate(): \DateTime|null
+    public function getDeliveryDate(): \DateTimeInterface|null
     {
         if (!$this->hasDeliveryDate()) {
             $this->setDeliveryDate($this->getDefaultDeliveryDate());
@@ -64,9 +64,9 @@ trait DeliveryDateTrait
     /**
      * Get a default delivery date value, if any is available
      *
-     * @return \DateTime|null Default delivery date value or null if no default value is available
+     * @return \DateTimeInterface|null Default delivery date value or null if no default value is available
      */
-    public function getDefaultDeliveryDate(): \DateTime|null
+    public function getDefaultDeliveryDate(): \DateTimeInterface|null
     {
         return null;
     }

--- a/packages/Support/src/Properties/Dates/EndDateTrait.php
+++ b/packages/Support/src/Properties/Dates/EndDateTrait.php
@@ -15,18 +15,18 @@ trait EndDateTrait
     /**
      * Date for when some kind of event ends
      *
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
-    protected \DateTime|null $endDate = null;
+    protected \DateTimeInterface|null $endDate = null;
 
     /**
      * Set end date
      *
-     * @param \DateTime|null $date Date for when some kind of event ends
+     * @param \DateTimeInterface|null $date Date for when some kind of event ends
      *
      * @return self
      */
-    public function setEndDate(\DateTime|null $date): static
+    public function setEndDate(\DateTimeInterface|null $date): static
     {
         $this->endDate = $date;
 
@@ -41,9 +41,9 @@ trait EndDateTrait
      *
      * @see getDefaultEndDate()
      *
-     * @return \DateTime|null end date or null if no end date has been set
+     * @return \DateTimeInterface|null end date or null if no end date has been set
      */
-    public function getEndDate(): \DateTime|null
+    public function getEndDate(): \DateTimeInterface|null
     {
         if (!$this->hasEndDate()) {
             $this->setEndDate($this->getDefaultEndDate());
@@ -64,9 +64,9 @@ trait EndDateTrait
     /**
      * Get a default end date value, if any is available
      *
-     * @return \DateTime|null Default end date value or null if no default value is available
+     * @return \DateTimeInterface|null Default end date value or null if no default value is available
      */
-    public function getDefaultEndDate(): \DateTime|null
+    public function getDefaultEndDate(): \DateTimeInterface|null
     {
         return null;
     }

--- a/packages/Support/src/Properties/Dates/ExpiresAtTrait.php
+++ b/packages/Support/src/Properties/Dates/ExpiresAtTrait.php
@@ -15,18 +15,18 @@ trait ExpiresAtTrait
     /**
      * Date of when this component, entity or resource is going to expire
      *
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
-    protected \DateTime|null $expiresAt = null;
+    protected \DateTimeInterface|null $expiresAt = null;
 
     /**
      * Set expires at
      *
-     * @param \DateTime|null $date Date of when this component, entity or resource is going to expire
+     * @param \DateTimeInterface|null $date Date of when this component, entity or resource is going to expire
      *
      * @return self
      */
-    public function setExpiresAt(\DateTime|null $date): static
+    public function setExpiresAt(\DateTimeInterface|null $date): static
     {
         $this->expiresAt = $date;
 
@@ -41,9 +41,9 @@ trait ExpiresAtTrait
      *
      * @see getDefaultExpiresAt()
      *
-     * @return \DateTime|null expires at or null if no expires at has been set
+     * @return \DateTimeInterface|null expires at or null if no expires at has been set
      */
-    public function getExpiresAt(): \DateTime|null
+    public function getExpiresAt(): \DateTimeInterface|null
     {
         if (!$this->hasExpiresAt()) {
             $this->setExpiresAt($this->getDefaultExpiresAt());
@@ -64,9 +64,9 @@ trait ExpiresAtTrait
     /**
      * Get a default expires at value, if any is available
      *
-     * @return \DateTime|null Default expires at value or null if no default value is available
+     * @return \DateTimeInterface|null Default expires at value or null if no default value is available
      */
-    public function getDefaultExpiresAt(): \DateTime|null
+    public function getDefaultExpiresAt(): \DateTimeInterface|null
     {
         return null;
     }

--- a/packages/Support/src/Properties/Dates/ProducedAtTrait.php
+++ b/packages/Support/src/Properties/Dates/ProducedAtTrait.php
@@ -15,18 +15,18 @@ trait ProducedAtTrait
     /**
      * Date of when this component, entity or something was produced
      *
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
-    protected \DateTime|null $producedAt = null;
+    protected \DateTimeInterface|null $producedAt = null;
 
     /**
      * Set produced at
      *
-     * @param \DateTime|null $date Date of when this component, entity or something was produced
+     * @param \DateTimeInterface|null $date Date of when this component, entity or something was produced
      *
      * @return self
      */
-    public function setProducedAt(\DateTime|null $date): static
+    public function setProducedAt(\DateTimeInterface|null $date): static
     {
         $this->producedAt = $date;
 
@@ -41,9 +41,9 @@ trait ProducedAtTrait
      *
      * @see getDefaultProducedAt()
      *
-     * @return \DateTime|null produced at or null if no produced at has been set
+     * @return \DateTimeInterface|null produced at or null if no produced at has been set
      */
-    public function getProducedAt(): \DateTime|null
+    public function getProducedAt(): \DateTimeInterface|null
     {
         if (!$this->hasProducedAt()) {
             $this->setProducedAt($this->getDefaultProducedAt());
@@ -64,9 +64,9 @@ trait ProducedAtTrait
     /**
      * Get a default produced at value, if any is available
      *
-     * @return \DateTime|null Default produced at value or null if no default value is available
+     * @return \DateTimeInterface|null Default produced at value or null if no default value is available
      */
-    public function getDefaultProducedAt(): \DateTime|null
+    public function getDefaultProducedAt(): \DateTimeInterface|null
     {
         return null;
     }

--- a/packages/Support/src/Properties/Dates/ProductionDateTrait.php
+++ b/packages/Support/src/Properties/Dates/ProductionDateTrait.php
@@ -15,18 +15,18 @@ trait ProductionDateTrait
     /**
      * Date of planned production
      *
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
-    protected \DateTime|null $productionDate = null;
+    protected \DateTimeInterface|null $productionDate = null;
 
     /**
      * Set production date
      *
-     * @param \DateTime|null $date Date of planned production
+     * @param \DateTimeInterface|null $date Date of planned production
      *
      * @return self
      */
-    public function setProductionDate(\DateTime|null $date): static
+    public function setProductionDate(\DateTimeInterface|null $date): static
     {
         $this->productionDate = $date;
 
@@ -41,9 +41,9 @@ trait ProductionDateTrait
      *
      * @see getDefaultProductionDate()
      *
-     * @return \DateTime|null production date or null if no production date has been set
+     * @return \DateTimeInterface|null production date or null if no production date has been set
      */
-    public function getProductionDate(): \DateTime|null
+    public function getProductionDate(): \DateTimeInterface|null
     {
         if (!$this->hasProductionDate()) {
             $this->setProductionDate($this->getDefaultProductionDate());
@@ -64,9 +64,9 @@ trait ProductionDateTrait
     /**
      * Get a default production date value, if any is available
      *
-     * @return \DateTime|null Default production date value or null if no default value is available
+     * @return \DateTimeInterface|null Default production date value or null if no default value is available
      */
-    public function getDefaultProductionDate(): \DateTime|null
+    public function getDefaultProductionDate(): \DateTimeInterface|null
     {
         return null;
     }

--- a/packages/Support/src/Properties/Dates/PurchaseDateTrait.php
+++ b/packages/Support/src/Properties/Dates/PurchaseDateTrait.php
@@ -15,18 +15,18 @@ trait PurchaseDateTrait
     /**
      * Date of planned purchase
      *
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
-    protected \DateTime|null $purchaseDate = null;
+    protected \DateTimeInterface|null $purchaseDate = null;
 
     /**
      * Set purchase date
      *
-     * @param \DateTime|null $date Date of planned purchase
+     * @param \DateTimeInterface|null $date Date of planned purchase
      *
      * @return self
      */
-    public function setPurchaseDate(\DateTime|null $date): static
+    public function setPurchaseDate(\DateTimeInterface|null $date): static
     {
         $this->purchaseDate = $date;
 
@@ -41,9 +41,9 @@ trait PurchaseDateTrait
      *
      * @see getDefaultPurchaseDate()
      *
-     * @return \DateTime|null purchase date or null if no purchase date has been set
+     * @return \DateTimeInterface|null purchase date or null if no purchase date has been set
      */
-    public function getPurchaseDate(): \DateTime|null
+    public function getPurchaseDate(): \DateTimeInterface|null
     {
         if (!$this->hasPurchaseDate()) {
             $this->setPurchaseDate($this->getDefaultPurchaseDate());
@@ -64,9 +64,9 @@ trait PurchaseDateTrait
     /**
      * Get a default purchase date value, if any is available
      *
-     * @return \DateTime|null Default purchase date value or null if no default value is available
+     * @return \DateTimeInterface|null Default purchase date value or null if no default value is available
      */
-    public function getDefaultPurchaseDate(): \DateTime|null
+    public function getDefaultPurchaseDate(): \DateTimeInterface|null
     {
         return null;
     }

--- a/packages/Support/src/Properties/Dates/PurchasedAtTrait.php
+++ b/packages/Support/src/Properties/Dates/PurchasedAtTrait.php
@@ -15,18 +15,18 @@ trait PurchasedAtTrait
     /**
      * Date of when this component, entity or resource was purchased
      *
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
-    protected \DateTime|null $purchasedAt = null;
+    protected \DateTimeInterface|null $purchasedAt = null;
 
     /**
      * Set purchased at
      *
-     * @param \DateTime|null $date Date of when this component, entity or resource was purchased
+     * @param \DateTimeInterface|null $date Date of when this component, entity or resource was purchased
      *
      * @return self
      */
-    public function setPurchasedAt(\DateTime|null $date): static
+    public function setPurchasedAt(\DateTimeInterface|null $date): static
     {
         $this->purchasedAt = $date;
 
@@ -41,9 +41,9 @@ trait PurchasedAtTrait
      *
      * @see getDefaultPurchasedAt()
      *
-     * @return \DateTime|null purchased at or null if no purchased at has been set
+     * @return \DateTimeInterface|null purchased at or null if no purchased at has been set
      */
-    public function getPurchasedAt(): \DateTime|null
+    public function getPurchasedAt(): \DateTimeInterface|null
     {
         if (!$this->hasPurchasedAt()) {
             $this->setPurchasedAt($this->getDefaultPurchasedAt());
@@ -64,9 +64,9 @@ trait PurchasedAtTrait
     /**
      * Get a default purchased at value, if any is available
      *
-     * @return \DateTime|null Default purchased at value or null if no default value is available
+     * @return \DateTimeInterface|null Default purchased at value or null if no default value is available
      */
-    public function getDefaultPurchasedAt(): \DateTime|null
+    public function getDefaultPurchasedAt(): \DateTimeInterface|null
     {
         return null;
     }

--- a/packages/Support/src/Properties/Dates/ReleaseDateTrait.php
+++ b/packages/Support/src/Properties/Dates/ReleaseDateTrait.php
@@ -15,18 +15,18 @@ trait ReleaseDateTrait
     /**
      * Date of planned release
      *
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
-    protected \DateTime|null $releaseDate = null;
+    protected \DateTimeInterface|null $releaseDate = null;
 
     /**
      * Set release date
      *
-     * @param \DateTime|null $date Date of planned release
+     * @param \DateTimeInterface|null $date Date of planned release
      *
      * @return self
      */
-    public function setReleaseDate(\DateTime|null $date): static
+    public function setReleaseDate(\DateTimeInterface|null $date): static
     {
         $this->releaseDate = $date;
 
@@ -41,9 +41,9 @@ trait ReleaseDateTrait
      *
      * @see getDefaultReleaseDate()
      *
-     * @return \DateTime|null release date or null if no release date has been set
+     * @return \DateTimeInterface|null release date or null if no release date has been set
      */
-    public function getReleaseDate(): \DateTime|null
+    public function getReleaseDate(): \DateTimeInterface|null
     {
         if (!$this->hasReleaseDate()) {
             $this->setReleaseDate($this->getDefaultReleaseDate());
@@ -64,9 +64,9 @@ trait ReleaseDateTrait
     /**
      * Get a default release date value, if any is available
      *
-     * @return \DateTime|null Default release date value or null if no default value is available
+     * @return \DateTimeInterface|null Default release date value or null if no default value is available
      */
-    public function getDefaultReleaseDate(): \DateTime|null
+    public function getDefaultReleaseDate(): \DateTimeInterface|null
     {
         return null;
     }

--- a/packages/Support/src/Properties/Dates/ReleasedAtTrait.php
+++ b/packages/Support/src/Properties/Dates/ReleasedAtTrait.php
@@ -15,18 +15,18 @@ trait ReleasedAtTrait
     /**
      * Date of when this component, entity or something was released
      *
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
-    protected \DateTime|null $releasedAt = null;
+    protected \DateTimeInterface|null $releasedAt = null;
 
     /**
      * Set released at
      *
-     * @param \DateTime|null $date Date of when this component, entity or something was released
+     * @param \DateTimeInterface|null $date Date of when this component, entity or something was released
      *
      * @return self
      */
-    public function setReleasedAt(\DateTime|null $date): static
+    public function setReleasedAt(\DateTimeInterface|null $date): static
     {
         $this->releasedAt = $date;
 
@@ -41,9 +41,9 @@ trait ReleasedAtTrait
      *
      * @see getDefaultReleasedAt()
      *
-     * @return \DateTime|null released at or null if no released at has been set
+     * @return \DateTimeInterface|null released at or null if no released at has been set
      */
-    public function getReleasedAt(): \DateTime|null
+    public function getReleasedAt(): \DateTimeInterface|null
     {
         if (!$this->hasReleasedAt()) {
             $this->setReleasedAt($this->getDefaultReleasedAt());
@@ -64,9 +64,9 @@ trait ReleasedAtTrait
     /**
      * Get a default released at value, if any is available
      *
-     * @return \DateTime|null Default released at value or null if no default value is available
+     * @return \DateTimeInterface|null Default released at value or null if no default value is available
      */
-    public function getDefaultReleasedAt(): \DateTime|null
+    public function getDefaultReleasedAt(): \DateTimeInterface|null
     {
         return null;
     }

--- a/packages/Support/src/Properties/Dates/StartDateTrait.php
+++ b/packages/Support/src/Properties/Dates/StartDateTrait.php
@@ -15,18 +15,18 @@ trait StartDateTrait
     /**
      * Start date of event
      *
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
-    protected \DateTime|null $startDate = null;
+    protected \DateTimeInterface|null $startDate = null;
 
     /**
      * Set start date
      *
-     * @param \DateTime|null $date Start date of event
+     * @param \DateTimeInterface|null $date Start date of event
      *
      * @return self
      */
-    public function setStartDate(\DateTime|null $date): static
+    public function setStartDate(\DateTimeInterface|null $date): static
     {
         $this->startDate = $date;
 
@@ -41,9 +41,9 @@ trait StartDateTrait
      *
      * @see getDefaultStartDate()
      *
-     * @return \DateTime|null start date or null if no start date has been set
+     * @return \DateTimeInterface|null start date or null if no start date has been set
      */
-    public function getStartDate(): \DateTime|null
+    public function getStartDate(): \DateTimeInterface|null
     {
         if (!$this->hasStartDate()) {
             $this->setStartDate($this->getDefaultStartDate());
@@ -64,9 +64,9 @@ trait StartDateTrait
     /**
      * Get a default start date value, if any is available
      *
-     * @return \DateTime|null Default start date value or null if no default value is available
+     * @return \DateTimeInterface|null Default start date value or null if no default value is available
      */
-    public function getDefaultStartDate(): \DateTime|null
+    public function getDefaultStartDate(): \DateTimeInterface|null
     {
         return null;
     }

--- a/packages/Support/src/Properties/Dates/UpdatedAtTrait.php
+++ b/packages/Support/src/Properties/Dates/UpdatedAtTrait.php
@@ -15,18 +15,18 @@ trait UpdatedAtTrait
     /**
      * Date of when this component, entity or resource was updated
      *
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
-    protected \DateTime|null $updatedAt = null;
+    protected \DateTimeInterface|null $updatedAt = null;
 
     /**
      * Set updated at
      *
-     * @param \DateTime|null $date Date of when this component, entity or resource was updated
+     * @param \DateTimeInterface|null $date Date of when this component, entity or resource was updated
      *
      * @return self
      */
-    public function setUpdatedAt(\DateTime|null $date): static
+    public function setUpdatedAt(\DateTimeInterface|null $date): static
     {
         $this->updatedAt = $date;
 
@@ -41,9 +41,9 @@ trait UpdatedAtTrait
      *
      * @see getDefaultUpdatedAt()
      *
-     * @return \DateTime|null updated at or null if no updated at has been set
+     * @return \DateTimeInterface|null updated at or null if no updated at has been set
      */
-    public function getUpdatedAt(): \DateTime|null
+    public function getUpdatedAt(): \DateTimeInterface|null
     {
         if (!$this->hasUpdatedAt()) {
             $this->setUpdatedAt($this->getDefaultUpdatedAt());
@@ -64,9 +64,9 @@ trait UpdatedAtTrait
     /**
      * Get a default updated at value, if any is available
      *
-     * @return \DateTime|null Default updated at value or null if no default value is available
+     * @return \DateTimeInterface|null Default updated at value or null if no default value is available
      */
-    public function getDefaultUpdatedAt(): \DateTime|null
+    public function getDefaultUpdatedAt(): \DateTimeInterface|null
     {
         return null;
     }

--- a/packages/Testing/src/Helpers/ArgumentFaker.php
+++ b/packages/Testing/src/Helpers/ArgumentFaker.php
@@ -3,6 +3,7 @@
 namespace Aedart\Testing\Helpers;
 
 use Closure;
+use DateTime;
 use Faker\Factory;
 use Faker\Generator;
 use Mockery as m;
@@ -104,7 +105,13 @@ class ArgumentFaker
      */
     public static function makeMockFor(string $target): MockInterface
     {
-        return m::mock($target);
+        // Handle special case - DateTimeInterface
+        $resolved = match ($target) {
+            'DateTimeInterface' => DateTime::class,
+            default => $target
+        };
+
+        return m::mock($resolved);
     }
 
     /**


### PR DESCRIPTION
Replaces the `\DateTime` type with `\DateTimeInterface` for all date related aware-of helpers. `\Aedart\Contracts\Utils\DataTypes::DATE_TIME_TYPE` is also changed.

See #75 