### PR TITLE
Improve core lang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `populate()` method now returns `static` instead of `void`, in `\Aedart\Contracts\Utils\Populatable` interface.
 * `all()` method added in `ApiResource` interface (_change is only breaking if you have custom implementation of interface_). [#54](https://github.com/aedart/athenaeum/issues/54).
 * `fresh()` method added in Http Client `Manager` (_change is only breaking if you have custom implementation of interface_). [#51](https://github.com/aedart/athenaeum/issues/51).
+* `PathsContainer` is now aware of "lang path" (_path to language files / directory_). The core application has also been modified to offer a `langPath()` method. [#76](https://github.com/aedart/athenaeum/issues/76).
 * Replaced `\DateTime` with `\DateTimeInterface` for all date related aware-of helpers. The `\Aedart\Contracts\Utils\DataTypes::DATE_TIME_TYPE` has also been changed. [#75](https://github.com/aedart/athenaeum/issues/75). 
 * `SearchFilter` no longer uses `StopWords` concern (_concern has been removed_). [#63](https://github.com/aedart/athenaeum/issues/63).
 * Return type of `package()` and `application()` is now set to `\Aedart\Contracts\Utils\Packages\Version`, in `\Aedart\Utils\Version`.  [#68](https://github.com/aedart/athenaeum/issues/68).

--- a/docs/archive/current/core/integration.md
+++ b/docs/archive/current/core/integration.md
@@ -35,6 +35,7 @@ return new \Aedart\Core\Application([
     'basePath' => dirname(__DIR__),
     'bootstrapPath' => dirname(__DIR__),
     'configPath' => __DIR__ . '/../configs',
+    'langPath' => __DIR__ . '/../lang',
     'databasePath' => __DIR__ . '/../database',
     'environmentPath' => __DIR__ . '/../',
     'resourcePath' => __DIR__ . '/../resources',

--- a/packages/Contracts/src/Core/Application.php
+++ b/packages/Contracts/src/Core/Application.php
@@ -29,6 +29,15 @@ interface Application extends IoC,
     public function publicPath();
 
     /**
+     * Get path to language files.
+     *
+     * @param  string  $path
+     *
+     * @return string
+     */
+    public function langPath(string $path = ''): string;
+
+    /**
      * Determine if running in "local" environment
      *
      * @return bool

--- a/packages/Contracts/src/Core/Helpers/PathsContainer.php
+++ b/packages/Contracts/src/Core/Helpers/PathsContainer.php
@@ -7,6 +7,7 @@ use Aedart\Contracts\Support\Properties\Strings\BootstrapPathAware;
 use Aedart\Contracts\Support\Properties\Strings\ConfigPathAware;
 use Aedart\Contracts\Support\Properties\Strings\DatabasePathAware;
 use Aedart\Contracts\Support\Properties\Strings\EnvironmentPathAware;
+use Aedart\Contracts\Support\Properties\Strings\LangPathAware;
 use Aedart\Contracts\Support\Properties\Strings\PublicPathAware;
 use Aedart\Contracts\Support\Properties\Strings\ResourcePathAware;
 use Aedart\Contracts\Support\Properties\Strings\StoragePathAware;
@@ -26,6 +27,7 @@ use JsonSerializable;
 interface PathsContainer extends BasePathAware,
     BootstrapPathAware,
     ConfigPathAware,
+    LangPathAware,
     DatabasePathAware,
     EnvironmentPathAware,
     ResourcePathAware,
@@ -62,6 +64,15 @@ interface PathsContainer extends BasePathAware,
      * @return string
      */
     public function configPath(string $path = ''): string;
+
+    /**
+     * Get path to language files.
+     *
+     * @param  string  $path
+     *
+     * @return string
+     */
+    public function langPath(string $path = ''): string;
 
     /**
      * Get a path with the "database" directory

--- a/packages/Core/helpers/paths.php
+++ b/packages/Core/helpers/paths.php
@@ -71,6 +71,20 @@ if (!function_exists('config_path')) {
     }
 }
 
+if (! function_exists('lang_path')) {
+    /**
+     * Get path to language files.
+     *
+     * @param  string  $path  [optional]
+     *
+     * @return string
+     */
+    function lang_path(string $path = ''): string
+    {
+        return paths()->langPath($path);
+    }
+}
+
 if (!function_exists('database_path')) {
 
     /**

--- a/packages/Core/src/Application.php
+++ b/packages/Core/src/Application.php
@@ -228,6 +228,14 @@ class Application extends IoC implements
     /**
      * @inheritDoc
      */
+    public function langPath(string $path = ''): string
+    {
+        return $this->getPathsContainer()->langPath($path);
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function databasePath($path = '')
     {
         return $this->getPathsContainer()->databasePath($path);
@@ -867,6 +875,7 @@ class Application extends IoC implements
         $this->instance('path.base', $this->basePath());
         $this->instance('path.bootstrap', $this->bootstrapPath());
         $this->instance('path.config', $this->configPath());
+        $this->instance('path.lang', $this->langPath());
         $this->instance('path.database', $this->databasePath());
         $this->instance('path.environment', $this->environmentPath());
         $this->instance('path.resource', $this->resourcePath());

--- a/packages/Core/src/Helpers/Paths.php
+++ b/packages/Core/src/Helpers/Paths.php
@@ -9,6 +9,7 @@ use Aedart\Support\Properties\Strings\BootstrapPathTrait;
 use Aedart\Support\Properties\Strings\ConfigPathTrait;
 use Aedart\Support\Properties\Strings\DatabasePathTrait;
 use Aedart\Support\Properties\Strings\EnvironmentPathTrait;
+use Aedart\Support\Properties\Strings\LangPathTrait;
 use Aedart\Support\Properties\Strings\PublicPathTrait;
 use Aedart\Support\Properties\Strings\ResourcePathTrait;
 use Aedart\Support\Properties\Strings\StoragePathTrait;
@@ -26,6 +27,7 @@ class Paths extends Dto implements PathsContainer
     use BasePathTrait;
     use BootstrapPathTrait;
     use ConfigPathTrait;
+    use LangPathTrait;
     use DatabasePathTrait;
     use EnvironmentPathTrait;
     use ResourcePathTrait;
@@ -54,6 +56,14 @@ class Paths extends Dto implements PathsContainer
     public function configPath(string $path = ''): string
     {
         return $this->getConfigPath() . DIRECTORY_SEPARATOR . $path;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function langPath(string $path = ''): string
+    {
+        return $this->getLangPath() . DIRECTORY_SEPARATOR . $path;
     }
 
     /**
@@ -103,7 +113,7 @@ class Paths extends Dto implements PathsContainer
     /**
      * @inheritdoc
      */
-    public function getDefaultBasePath(): ?string
+    public function getDefaultBasePath(): string|null
     {
         return getcwd();
     }
@@ -111,7 +121,7 @@ class Paths extends Dto implements PathsContainer
     /**
      * @inheritdoc
      */
-    public function getDefaultBootstrapPath(): ?string
+    public function getDefaultBootstrapPath(): string|null
     {
         return $this->getBasePath() . DIRECTORY_SEPARATOR . 'bootstrap';
     }
@@ -119,15 +129,32 @@ class Paths extends Dto implements PathsContainer
     /**
      * @inheritdoc
      */
-    public function getDefaultConfigPath(): ?string
+    public function getDefaultConfigPath(): string|null
     {
         return $this->getBasePath() . DIRECTORY_SEPARATOR . 'config';
     }
 
     /**
+     * @inheritDoc
+     */
+    public function getDefaultLangPath(): string|null
+    {
+        // If a "lang" directory already exists in the resource path,
+        // then use it. This is to ensure that we do not break backwards
+        // compatibility with previous version (pre v6.x).
+        // This is pretty much the same logic as Laravel v9.x uses.
+        $dir = $this->resourcePath('lang');
+        if (is_dir($dir)) {
+            return $dir;
+        }
+
+        return $this->getBasePath() . DIRECTORY_SEPARATOR . 'lang';
+    }
+
+    /**
      * @inheritdoc
      */
-    public function getDefaultDatabasePath(): ?string
+    public function getDefaultDatabasePath(): string|null
     {
         return $this->getBasePath() . DIRECTORY_SEPARATOR . 'database';
     }
@@ -135,7 +162,7 @@ class Paths extends Dto implements PathsContainer
     /**
      * @inheritdoc
      */
-    public function getDefaultEnvironmentPath(): ?string
+    public function getDefaultEnvironmentPath(): string|null
     {
         return $this->getBasePath();
     }
@@ -143,7 +170,7 @@ class Paths extends Dto implements PathsContainer
     /**
      * @inheritdoc
      */
-    public function getDefaultResourcePath(): ?string
+    public function getDefaultResourcePath(): string|null
     {
         return $this->getBasePath() . DIRECTORY_SEPARATOR . 'resources';
     }
@@ -151,7 +178,7 @@ class Paths extends Dto implements PathsContainer
     /**
      * @inheritdoc
      */
-    public function getDefaultStoragePath(): ?string
+    public function getDefaultStoragePath(): string|null
     {
         return $this->getBasePath() . DIRECTORY_SEPARATOR . 'storage';
     }
@@ -159,7 +186,7 @@ class Paths extends Dto implements PathsContainer
     /**
      * @inheritdoc
      */
-    public function getDefaultPublicPath(): ?string
+    public function getDefaultPublicPath(): string|null
     {
         return $this->getBasePath() . DIRECTORY_SEPARATOR . 'public';
     }

--- a/packages/Testing/src/Athenaeum/ApplicationInitiator.php
+++ b/packages/Testing/src/Athenaeum/ApplicationInitiator.php
@@ -158,6 +158,7 @@ trait ApplicationInitiator
             'basePath' => $root,
             'bootstrapPath' => $root . DIRECTORY_SEPARATOR . 'bootstrap',
             'configPath' => $root . DIRECTORY_SEPARATOR . 'config',
+            'langPath' => $root . DIRECTORY_SEPARATOR . 'lang',
             'databasePath' => $root . DIRECTORY_SEPARATOR . 'database',
             'environmentPath' => $root,
             'resourcePath' => $root . DIRECTORY_SEPARATOR . 'resources',

--- a/tests/Integration/Core/Application/A2_PathsTest.php
+++ b/tests/Integration/Core/Application/A2_PathsTest.php
@@ -84,6 +84,18 @@ class A2_PathsTest extends AthenaeumCoreTestCase
 
     /**
      * @test
+     *
+     * @return void
+     */
+    public function canReadLangPath()
+    {
+        $path = $this->app->langPath();
+
+        $this->assertNotEmpty($path);
+    }
+
+    /**
+     * @test
      */
     public function canReadDatabasePath()
     {


### PR DESCRIPTION
Added `langPath()` method to core `Application` and made the `PathsContainer` aware of "lang path".
This is done to be as compatible with Laravel `v9.x` as possible.

See #76 