### PR TITLE
Improve Dto and ArrayDto, resolve union types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `Dto` and `ArrayDto` can now accept and resolve union types. [#82](https://github.com/aedart/athenaeum/issues/82).
 * Maintenance Mode package that offers additional drivers for Laravel's Application, when using `php artisan down`. Available drivers: `'array'` and `'json'`. [#67](https://github.com/aedart/athenaeum/issues/67).
 * `EnvironmentHandler` interface in Core package, as a replacement for the application environment related methods, that were removed from Laravel's foundation `Application` interface in version `9.x`. [#85](https://github.com/aedart/athenaeum/pull/85)
 * `whereSlugNotIn()` method in `\Aedart\Database\Models\Concerns\Slugs` (_`Sluggable` interface also defines method_). [#64](https://github.com/aedart/athenaeum/issues/64).
@@ -52,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Replaced property calls with method calls, on faker instance throughout many tests (_PHP faker deprecated several properties since `v1.14`_). [#23](https://github.com/aedart/athenaeum/issues/23).  
 * Upgraded to [Symplify Monorepo Builder](https://github.com/symplify/monorepo-builder) `v10.x`. [#60](https://github.com/aedart/athenaeum/issues/60), [#65](https://github.com/aedart/athenaeum/pull/65).
 * `\Aedart\Utils\Dates\Duration` now inherits from `Stringable`.
+* `castAsDate()` now also accepts `DateTimeInterface` as argument, in `ArrayDto`. [#82](https://github.com/aedart/athenaeum/issues/82)
 * Replaced `get_class()` calls with the use of new `::class` magic constant (_[introduced in PHP 8](https://www.php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class.class)_). Change is throughout all packages.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Documentation for `\Aedart\Utils\Arr::differenceAssoc()` (_previously undocumented. Method was added in `v5.17`_). [#45](https://github.com/aedart/athenaeum/issues/45).
 * Documentation for `\Aedart\Utils\Helpers\Invoker` (_previously undocumented. Helper was added in `v5.12`_).
 * `InteractsWithDeprecationHandling` added to `LaravelTestHelper`.
+* `isValid()` method in `Json` utility.
 
 ### Changed
 

--- a/packages/Dto/src/Partials/CastingPartial.php
+++ b/packages/Dto/src/Partials/CastingPartial.php
@@ -7,7 +7,9 @@ use Carbon\Carbon;
 use DateTimeInterface;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use JsonException;
+use LogicException;
 use Throwable;
+use TypeError;
 
 /**
  * Casting Partial
@@ -20,6 +22,11 @@ use Throwable;
  */
 trait CastingPartial
 {
+    /**
+     * "no match" identifier
+     */
+    private static string $noMatch = '|@no_match@|';
+
     /**
      * Cast given property's value
      *
@@ -42,17 +49,117 @@ trait CastingPartial
 
         // Cast value to assigned type
         $type = $this->allowed[$name];
+        if ($this->isUnionType($type)) {
+            return $this->resolveUnionType($type, $name, $value);
+        }
+
         return match ($type) {
             'string', 'str' => $this->castAsString($value),
             'integer', 'int' => $this->castAsInteger($value),
             'float', 'double' => $this->castAsFloat($value),
             'boolean', 'bool' => $this->castAsBoolean($value),
-            'array' => $this->castAsArray($value),
+            'array', 'arr' => $this->castAsArray($value),
             'date' => $this->castAsDate($value),
+
+            // Not sure when this ever will be useful, but we allow it...
+            'null' && is_null($value) => null,
 
             // We assume that it's an object that must be resolved via the IoC
             default => $this->resolveClassAndPopulate($type, $name, $value)
         };
+    }
+
+    /**
+     * Determine if type is a union type
+     *
+     * @param string|array $type
+     *
+     * @return bool
+     */
+    protected function isUnionType(string|array $type): bool
+    {
+        return is_array($type) || str_contains($type, '|');
+    }
+
+    /**
+     * Resolve union type
+     *
+     * @param  string|array  $allowedTypes List of allowed data types
+     * @param  string $name Name of property
+     * @param  mixed $value Value to cast
+     *
+     * @return mixed
+     *
+     * @throws BindingResolutionException
+     * @throws JsonException
+     * @throws Throwable
+     */
+    protected function resolveUnionType(string|array $allowedTypes, string $name, mixed $value): mixed
+    {
+        if (is_string($allowedTypes)) {
+            $allowedTypes = explode('|', $allowedTypes);
+        }
+
+        if (empty($allowedTypes)) {
+            throw new LogicException(sprintf('Invalid allowed union types declared for %s', $name));
+        }
+
+        foreach ($allowedTypes as $type) {
+
+            $result = match(true) {
+                in_array($type, ['string', 'str']) && is_string($value) => $this->castAsString($value),
+                in_array($type, ['integer', 'int']) && is_integer($value) => $this->castAsInteger($value),
+                in_array($type, ['float', 'double']) && is_float($value) => $this->castAsFloat($value),
+                in_array($type, ['boolean', 'bool']) && is_bool($value) => $this->castAsBoolean($value),
+                in_array($type, ['array', 'arr']) && (is_array($value) || is_string($value)) => $this->castAsArray($value),
+                $type === 'date' && ($value instanceof DateTimeInterface || is_string($value)) => $this->castAsDate($value),
+                $type === 'null' && is_null($value) => null,
+
+                // When type is a class path and value is an instance of the type...
+                class_exists($type) && is_object($value) && $value instanceof $type => $this->resolveClassAndPopulate($type, $name, $value),
+
+                // When type is a class and an array value is given, we assume that type is a DTO or populate instance.
+                class_exists($type) && is_array($value) => $this->attemptPopulateDtoWithArray($type, $name, $value),
+
+                // Otherwise, we need to skip and allow next type to be processed
+                default => static::$noMatch
+            };
+
+            if ($result !== static::$noMatch) {
+                return $result;
+            }
+        }
+
+        // This means that everything else has failed, and we do not know how to handle the given type.
+        throw new TypeError(sprintf(
+            'Unable to set property $%s. %s expected, but was %s given.',
+            $name,
+            implode('|', $allowedTypes),
+            var_export($value, true)
+        ));
+    }
+
+    /**
+     * Attempt to populate a user-defined class, e.g. DTO or populatable with array
+     * data
+     *
+     * @param  string  $type
+     * @param  string  $parameter
+     * @param  array  $value
+     *
+     * @return mixed Populated DTO or returns "no match" identifier when no able to populate given type
+     *
+     * @throws BindingResolutionException
+     * @throws Throwable
+     */
+    protected function attemptPopulateDtoWithArray(string $type, string $parameter, array $value): mixed
+    {
+        $resolved = $this->attemptPopulateUserDefinedClass($type, $parameter, $value);
+        if (!isset($resolved)) {
+            return static::$noMatch;
+        }
+
+        return $resolved;
     }
 
     /**
@@ -123,11 +230,11 @@ trait CastingPartial
     /**
      * Cast given value to a DateTime instance
      *
-     * @param string|null $value
+     * @param string|DateTimeInterface|null $value
      *
      * @return Carbon|DateTimeInterface
      */
-    protected function castAsDate(string|null $value): Carbon|DateTimeInterface
+    protected function castAsDate(string|DateTimeInterface|null $value): Carbon|DateTimeInterface
     {
         return Carbon::parse($value);
     }

--- a/packages/Dto/src/Partials/IoCPartial.php
+++ b/packages/Dto/src/Partials/IoCPartial.php
@@ -2,16 +2,19 @@
 
 namespace Aedart\Dto\Partials;
 
+use Aedart\Contracts\Dto;
 use Aedart\Contracts\Utils\Populatable;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Facades\App;
 use ReflectionClass;
 use ReflectionException;
+use ReflectionNamedType;
 use ReflectionParameter;
 use ReflectionType;
 use ReflectionUnionType;
 use Throwable;
+use TypeError;
 
 /**
  * IoC Partial
@@ -114,20 +117,7 @@ trait IoCPartial
 
         // When union type given...
         if ($type instanceof ReflectionUnionType) {
-            $types = $type->getTypes();
-
-            $allAreBuiltIn = true;
-            foreach ($types as $t){
-                if (!$t->isBuiltin()) {
-                    $allAreBuiltIn = false;
-                    break;
-                }
-            }
-
-            // Return value if all union types are builtin
-            if ($allAreBuiltIn) {
-                return $value;
-            }
+            return $this->resolveUnionTypeParameter($type, $value, $parameter->getName());
         }
 
         // When a reflection type
@@ -145,6 +135,102 @@ trait IoCPartial
 
         // Finally, resolve the class instance and populate it
         return $this->resolveClassAndPopulate($className, $parameter, $value);
+    }
+
+    /**
+     * Resolve union type parameter
+     *
+     * @param  ReflectionUnionType  $parameter The setter method's union type parameter reflection
+     * @param  mixed  $value The value to be passed to the setter method
+     * @param  string  $parameterName Name of parameter
+     *
+     * @return mixed
+     *
+     * @throws BindingResolutionException
+     * @throws ReflectionException
+     * @throws Throwable
+     */
+    protected function resolveUnionTypeParameter(ReflectionUnionType $parameter, mixed $value, string $parameterName): mixed
+    {
+        $unionTypes = $parameter->getTypes();
+        $isScalar = is_scalar($value);
+
+        // Note: the gettype return values are NOT comparable with the ReflectionUnionType::getName()!
+        // But we can use this in case of arrays, objects... etc.
+        $valueType = gettype($value);
+
+        foreach ($unionTypes as $type) {
+            $typeName = $type->getName();
+            $isBuiltin = $type->isBuiltin();
+
+            // Whenever a scalar type is given (int, float, string or bool) and the type
+            // is considered builtin, we simply return the value.
+            if ($isBuiltin && $isScalar) {
+                return $value;
+            }
+
+            // When builtin type is an array and the value type is also an array,
+            // to return it...
+            if ($isBuiltin && $typeName === 'array' && $valueType === 'array') {
+                return $value;
+            }
+
+            // In case that "null" is provided and it is allowed...
+            if ($valueType === 'NULL' && $type->allowsNull()) {
+                return $value;
+            }
+
+            // When an object is given that is an instance of the type, return it...
+            if (!$isBuiltin && $valueType === 'object' && $value instanceof $typeName) {
+                return $value;
+            }
+
+            // Lastly, when type is an object that can be populated and an array is given,
+            // then we attempt to resolve the class type and populate it, if the populatable
+            // instance accepts the keys from given array value...
+            if (!$isBuiltin && $valueType === 'array') {
+                $typeReflection = new ReflectionClass($typeName);
+                $userDefined = $typeReflection->isUserDefined();
+
+                if ($userDefined && $typeReflection->implementsInterface(Dto::class)) {
+
+                    // EDGE-CASE: when multiple DTOs are allowed and array data is provided, then we must ensure
+                    // that we only attempt to populate the instance that matches all keys from given array value.
+                    // Otherwise, we could end up attempting to populating an incorrect DTO.
+                    // This is not a 100% guarantee. If two different DTOs accept the same properties, then the
+                    // first DTO that is type-hinted will be populated, even though the developer might have
+                    // intended the second one to be populated.
+
+                    /** @var Dto $instance */
+                    $instance = $this->resolveInstanceFromIoC($typeName, $parameterName, $value);
+
+                    $populatable = $instance->populatableProperties();
+                    $keys = array_keys($value);
+
+                    if (count(array_intersect($keys, $populatable)) === count($keys)) {
+                        return $this->resolveInstancePopulation($instance, $parameterName, $value);
+                    }
+                } elseif ($userDefined && $typeReflection->implementsInterface(Populatable::class)) {
+                    // In case that it's not a DTO, yet still an object that is populatable, then attempt
+                    // to populate it.
+                    return $this->resolveClassAndPopulate($typeName, $parameterName, $value);
+                }
+
+                // Otherwise, we will allow loop to continue to next type...
+            }
+        }
+
+        // This means that everything else has failed, and we do not know how to handle the given type.
+        $allowedTypes = implode('|', array_map(function(ReflectionNamedType $type) {
+            return $type->getName();
+        }, $unionTypes));
+
+        throw new TypeError(sprintf(
+            'Unable to set property $%s. %s expected, but was %s given.',
+            $parameterName,
+            $allowedTypes,
+            var_export($value, true)
+        ));
     }
 
     /**
@@ -172,21 +258,39 @@ trait IoCPartial
             $name = $parameter->getName();
         }
 
+        // Resolve instance from service container and populate it
+        $instance = $this->resolveInstanceFromIoC($class, $name, $value);
+
+        return $this->resolveInstancePopulation($instance, $parameter, $value);
+    }
+
+    /**
+     * Resolve instance from Service Container
+     *
+     * @param  string  $class
+     * @param  string  $property
+     * @param  mixed  $value
+     *
+     * @return mixed
+     *
+     * @throws BindingResolutionException
+     */
+    protected function resolveInstanceFromIoC(string $class, string $property, mixed $value): mixed
+    {
         // Fail if no service container is available
         $container = $this->container();
-        if (!isset($container)) {
-            $message = sprintf(
-                'No IoC Service Container is available, cannot resolve property "%s" of the type "%s"; do not know how to populate with "%s"',
-                $name,
-                $class,
-                var_export($value, true)
-            );
-            throw new BindingResolutionException($message);
+        if (isset($container)) {
+            return $container->make($class);
         }
 
-        // Populate instance
-        $instance = $container->make($class);
-        return $this->resolveInstancePopulation($instance, $parameter, $value);
+        $message = sprintf(
+            'No IoC Service Container is available, cannot resolve property "%s" of the type "%s"; do not know how to populate with "%s"',
+            $property,
+            $class,
+            var_export($value, true)
+        );
+
+        throw new BindingResolutionException($message);
     }
 
     /**

--- a/packages/Utils/src/Json.php
+++ b/packages/Utils/src/Json.php
@@ -59,4 +59,22 @@ class Json
 
         return json_decode($json, $assoc, $depth, $options);
     }
+
+    /**
+     * Determine if given value is a valid json encoded string
+     *
+     * @param  mixed  $value
+     *
+     * @return bool False if not a string or if invalid encoded json
+     */
+    public static function isValid(mixed $value): bool
+    {
+        if (!is_string($value)) {
+            return false;
+        }
+
+        @json_decode($value);
+
+        return json_last_error() === JSON_ERROR_NONE;
+    }
 }

--- a/tests/Helpers/Dummies/Dto/Article.php
+++ b/tests/Helpers/Dummies/Dto/Article.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Aedart\Tests\Helpers\Dummies\Dto;
+
+use Aedart\Dto\ArrayDto;
+use DateTimeInterface;
+use Illuminate\Support\Carbon;
+
+/**
+ * Article
+ *
+ * FOR TESTING PURPOSES ONLY
+ *
+ * @property string|int|float|bool|null $id Article id
+ * @property array|null $content Content
+ * @property DateTimeInterface|Carbon|null $createdAt Datetime of when article was created
+ * @property string|Person|Organisation|null $author Author of article
+ *
+ * @author Alin Eugen Deac <aedart@gmail.com>
+ * @package Aedart\Tests\Helpers\Dummies\Dto
+ */
+class Article extends ArrayDto
+{
+    protected array $allowed = [
+        'id' => 'string|int|float|bool|null',
+        'content' => 'array|null',
+        'createdAt' => 'date|null',
+        'author' => ['string', Person::class, Organisation::class, 'null'],
+    ];
+}

--- a/tests/Helpers/Dummies/Dto/Record.php
+++ b/tests/Helpers/Dummies/Dto/Record.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Aedart\Tests\Helpers\Dummies\Dto;
+
+use Aedart\Dto\Dto;
+
+/**
+ * Record
+ *
+ * FOR TESTING PURPOSES ONLY
+ *
+ * @property string|int|float|bool|null $id Record id
+ * @property array|null $data Record data...
+ * @property string|Person|Organisation|null $reference Reference to something...
+ *
+ * @author Alin Eugen Deac <aedart@gmail.com>
+ * @package Aedart\Tests\Helpers\Dummies\Dto
+ */
+class Record extends Dto
+{
+    /**
+     * Record id
+     *
+     * NOTE: The "strange" types are on purpose for testing purposes!
+     *
+     * @var string|int|float|bool|null
+     */
+    protected string|int|float|bool|null $id = null;
+
+    /**
+     * Data
+     *
+     * @var string|array|null
+     */
+    protected string|array|null $data = null;
+
+    /**
+     * Reference to something...
+     *
+     * @var string|Person|Organisation|null
+     */
+    protected string|Person|Organisation|null $reference = null;
+
+    /**
+     * Set the id
+     *
+     * @param  string|int|float|bool|null  $id
+     *
+     * @return self
+     */
+    public function setId(string|int|float|bool|null $id): static
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * Get the id
+     *
+     * @return string|int|float|bool|null
+     */
+    public function getId(): string|int|float|bool|null
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set data
+     *
+     * @param  string|array|null  $data
+     *
+     * @return self
+     */
+    public function setData(string|array|null $data): static
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * Get data
+     *
+     * @return string|array|null
+     */
+    public function getData(): string|array|null
+    {
+        return $this->data;
+    }
+
+    /**
+     * Set reference
+     *
+     * @param  string|Person|Organisation|null  $reference
+     *
+     * @return self
+     */
+    public function setReference(string|Person|Organisation|null $reference): static
+    {
+        $this->reference = $reference;
+
+        return $this;
+    }
+
+    /**
+     * Get reference
+     *
+     * @return string|Person|Organisation|null
+     */
+    public function getReference(): string|Person|Organisation|null
+    {
+        return $this->reference;
+    }
+}

--- a/tests/Integration/Dto/ResolveArrayDtoUnionTypesTest.php
+++ b/tests/Integration/Dto/ResolveArrayDtoUnionTypesTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Aedart\Tests\Integration\Dto;
+
+use Aedart\Tests\Helpers\Dummies\Dto\Organisation;
+use Aedart\Tests\Helpers\Dummies\Dto\Person;
+use Aedart\Tests\TestCases\Dto\DtoTestCase;
+use Aedart\Utils\Json;
+use DateTimeInterface;
+use Illuminate\Support\Carbon;
+use JsonException;
+use TypeError;
+
+/**
+ * ResolveArrayDtoUnionTypesTest
+ *
+ * @group dto
+ * @group dto-union-types
+ * @group array-dto-union-types
+ *
+ * @author Alin Eugen Deac <aedart@gmail.com>
+ * @package Aedart\Tests\Integration\Dto
+ */
+class ResolveArrayDtoUnionTypesTest extends DtoTestCase
+{
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function resolvesScalarTypes()
+    {
+        $faker = $this->getFaker();
+
+        $dtoA = $this->makeArrayDtoWithUnionTypes([ 'id' => (string) $faker->randomDigitNotNull() ]);
+        $this->assertTrue(isset($dtoA->id), 'Id not set (a: string)');
+        $this->assertIsString($dtoA->id);
+
+        $dtoB = $this->makeArrayDtoWithUnionTypes([ 'id' => $faker->randomDigitNotNull() ]);
+        $this->assertTrue(isset($dtoB->id), 'Id not set (b: int)');
+        $this->assertIsInt($dtoB->id);
+
+        $dtoC = $this->makeArrayDtoWithUnionTypes([ 'id' => $faker->randomFloat() ]);
+        $this->assertTrue(isset($dtoC->id), 'Id not set (c: float)');
+        $this->assertIsFloat($dtoC->id);
+
+        $dtoD = $this->makeArrayDtoWithUnionTypes([ 'id' => $faker->boolean() ]);
+        $this->assertTrue(isset($dtoD->id), 'Id not set (d: bool)');
+        $this->assertIsBool($dtoD->id);
+
+        $dtoE = $this->makeArrayDtoWithUnionTypes([ 'id' => null ]);
+        $this->assertFalse(isset($dtoE->id), 'Id set (c: null), but should be null');
+        $this->assertNull($dtoE->id);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     *
+     * @throws JsonException
+     */
+    public function resolvesArrayTypes()
+    {
+        $faker = $this->getFaker();
+
+        $dtoA = $this->makeArrayDtoWithUnionTypes([ 'content' => Json::encode([ 'body' => $faker->text() ]) ]);
+        $this->assertTrue(isset($dtoA->content), 'Content not set (a: json string)');
+        $this->assertIsArray($dtoA->content);
+
+        $dtoB = $this->makeArrayDtoWithUnionTypes([ 'content' => [ 'body' => $faker->text() ] ]);
+        $this->assertTrue(isset($dtoB->content), 'Content not set (b: array)');
+        $this->assertIsArray($dtoB->content);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function resolvesDateTypes()
+    {
+        $dtoA = $this->makeArrayDtoWithUnionTypes([ 'createdAt' => Carbon::now() ]);
+        $this->assertTrue(isset($dtoA->createdAt), 'createdAt not set (a: Datetime / Carbon)');
+        $this->assertInstanceOf(DateTimeInterface::class, $dtoA->createdAt);
+
+        $dtoB = $this->makeArrayDtoWithUnionTypes([ 'createdAt' => 'now' ]);
+        $this->assertTrue(isset($dtoB->createdAt), 'createdAt not set (a: string (now))');
+        $this->assertInstanceOf(DateTimeInterface::class, $dtoB->createdAt);
+
+        $dtoC = $this->makeArrayDtoWithUnionTypes([ 'createdAt' => '+1 week' ]);
+        $this->assertTrue(isset($dtoC->createdAt), 'createdAt not set (a: string (+1 week))');
+        $this->assertInstanceOf(DateTimeInterface::class, $dtoC->createdAt);
+
+        $dtoD = $this->makeArrayDtoWithUnionTypes([ 'createdAt' => null ]);
+        $this->assertFalse(isset($dtoD->createdAt), 'createdAt set (a: null) BUT SHOULD NOT BE');
+        $this->assertNull($dtoD->createdAt);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function resolvesObjectTypes()
+    {
+        $faker = $this->getFaker();
+
+        $dtoA = $this->makeArrayDtoWithUnionTypes([ 'author' => $faker->name() ]);
+        $this->assertTrue(isset($dtoA->author), 'Author not set (a: string)');
+        $this->assertIsString($dtoA->author);
+
+        $dtoB = $this->makeArrayDtoWithUnionTypes([ 'author' => Person::makeNew([ 'name' => $faker->name() ]) ]);
+        $this->assertTrue(isset($dtoB->author), 'Author not set (a: Person)');
+        $this->assertInstanceOf(Person::class, $dtoB->author);
+
+        // Note: both person and organisation have key "name", but since person is defined first,
+        // we expect it to be populated
+        $dtoC = $this->makeArrayDtoWithUnionTypes([ 'author' => [ 'name' => $faker->name() ] ]);
+        $this->assertTrue(isset($dtoC->author), 'Author not set (a: array -> Person)');
+        $this->assertInstanceOf(Person::class, $dtoC->author);
+
+        $dtoD = $this->makeArrayDtoWithUnionTypes([ 'author' => Organisation::makeNew([ 'name' => $faker->company() ]) ]);
+        $this->assertTrue(isset($dtoD->author), 'Author not set (a: Organisation)');
+        $this->assertInstanceOf(Organisation::class, $dtoD->author);
+
+        // Note: given array data matches the keys of Organisation and not Person, which is what we expect!
+        $dtoE = $this->makeArrayDtoWithUnionTypes([ 'author' => [ 'name' => $faker->company(), 'slogan' => $faker->name() ] ]);
+        $this->assertTrue(isset($dtoE->author), 'Author not set (a: array -> Organisation)');
+        $this->assertInstanceOf(Organisation::class, $dtoE->author);
+
+        // Note: keys only match properties in Organisation, so this is what we expect!
+        $dtoF = $this->makeArrayDtoWithUnionTypes([ 'author' => [ 'slogan' => $faker->sentence(4) ] ]);
+        $this->assertTrue(isset($dtoF->author), 'Reference not set (g: array -> Organisation)');
+        $this->assertInstanceOf(Organisation::class, $dtoF->author);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function failsWhenUnableToResolveType()
+    {
+        $this->expectException(TypeError::class);
+
+        $this->makeArrayDtoWithUnionTypes([ 'author' => [1, 2, 3] ]);
+    }
+}

--- a/tests/Integration/Dto/ResolveDtoUnionTypesTest.php
+++ b/tests/Integration/Dto/ResolveDtoUnionTypesTest.php
@@ -28,23 +28,22 @@ class ResolveDtoUnionTypesTest extends DtoTestCase
         $faker = $this->getFaker();
 
         $dtoA = $this->makeDtoWithUnionTypes([ 'id' => (string) $faker->randomDigitNotNull() ]);
-        $dtoB = $this->makeDtoWithUnionTypes([ 'id' => $faker->randomDigitNotNull() ]);
-        $dtoC = $this->makeDtoWithUnionTypes([ 'id' => $faker->randomFloat() ]);
-        $dtoD = $this->makeDtoWithUnionTypes([ 'id' => $faker->boolean() ]);
-        $dtoE = $this->makeDtoWithUnionTypes([ 'id' => null ]);
-
         $this->assertTrue(isset($dtoA->id), 'Id not set (a: string)');
         $this->assertIsString($dtoA->id);
 
+        $dtoB = $this->makeDtoWithUnionTypes([ 'id' => $faker->randomDigitNotNull() ]);
         $this->assertTrue(isset($dtoB->id), 'Id not set (b: int)');
         $this->assertIsInt($dtoB->id);
 
+        $dtoC = $this->makeDtoWithUnionTypes([ 'id' => $faker->randomFloat() ]);
         $this->assertTrue(isset($dtoC->id), 'Id not set (c: float)');
         $this->assertIsFloat($dtoC->id);
 
+        $dtoD = $this->makeDtoWithUnionTypes([ 'id' => $faker->boolean() ]);
         $this->assertTrue(isset($dtoD->id), 'Id not set (d: bool)');
         $this->assertIsBool($dtoD->id);
 
+        $dtoE = $this->makeDtoWithUnionTypes([ 'id' => null ]);
         $this->assertFalse(isset($dtoE->id), 'Id set (c: null), but should be null');
         $this->assertNull($dtoE->id);
     }
@@ -59,11 +58,12 @@ class ResolveDtoUnionTypesTest extends DtoTestCase
         $faker = $this->getFaker();
 
         $dtoA = $this->makeDtoWithUnionTypes([ 'data' => $faker->words(3, true) ]);
-        $dtoB = $this->makeDtoWithUnionTypes([ 'data' => $faker->words(3) ]);
-        $dtoC = $this->makeDtoWithUnionTypes([ 'data' => null ]);
-
         $this->assertTrue(isset($dtoA->data), 'Data not set (a: string)');
+
+        $dtoB = $this->makeDtoWithUnionTypes([ 'data' => $faker->words(3) ]);
         $this->assertTrue(isset($dtoB->data), 'Data not set (a: array)');
+
+        $dtoC = $this->makeDtoWithUnionTypes([ 'data' => null ]);
         $this->assertFalse(isset($dtoC->data), 'Data set (b: null), but should be null');
     }
 
@@ -77,26 +77,27 @@ class ResolveDtoUnionTypesTest extends DtoTestCase
         $faker = $this->getFaker();
 
         $dtoA = $this->makeDtoWithUnionTypes([ 'reference' => $faker->words(3, true) ]);
-        $dtoB = $this->makeDtoWithUnionTypes([ 'reference' => Person::makeNew([ 'name' => $faker->name() ]) ]);
-        $dtoC = $this->makeDtoWithUnionTypes([ 'reference' => [ 'name' => $faker->name() ] ]);
-        $dtoD = $this->makeDtoWithUnionTypes([ 'reference' => Organisation::makeNew( ['name' => $faker->company(), 'slogan' => $faker->sentence(4) ] ) ]);
-        $dtoE = $this->makeDtoWithUnionTypes([ 'reference' => [ 'name' => $faker->company(), 'slogan' => $faker->sentence(4) ] ]);
-        $dtoF = $this->makeDtoWithUnionTypes([ 'reference' => [ 'slogan' => $faker->sentence(4) ] ]);
-
         $this->assertTrue(isset($dtoA->reference), 'Reference not set (a: string)');
 
         // Note: both person and organisation have key "name", but since person is defined first,
         // we expect it to be populated
+        $dtoB = $this->makeDtoWithUnionTypes([ 'reference' => Person::makeNew([ 'name' => $faker->name() ]) ]);
         $this->assertTrue(isset($dtoB->reference), 'Reference not set (b: Person)');
+
+        $dtoC = $this->makeDtoWithUnionTypes([ 'reference' => [ 'name' => $faker->name() ] ]);
         $this->assertTrue(isset($dtoC->reference), 'Reference not set (c: array -> Person)');
         $this->assertInstanceOf(Person::class, $dtoC->reference);
 
         // Note: given array data matches the keys of Organisation and not Person, which is what we expect!
+        $dtoD = $this->makeDtoWithUnionTypes([ 'reference' => Organisation::makeNew( ['name' => $faker->company(), 'slogan' => $faker->sentence(4) ] ) ]);
         $this->assertTrue(isset($dtoD->reference), 'Reference not set (d: Organisation)');
+
+        $dtoE = $this->makeDtoWithUnionTypes([ 'reference' => [ 'name' => $faker->company(), 'slogan' => $faker->sentence(4) ] ]);
         $this->assertTrue(isset($dtoE->reference), 'Reference not set (e: array -> Organisation)');
         $this->assertInstanceOf(Organisation::class, $dtoE->reference);
 
         // Note: keys only match properties in Organisation
+        $dtoF = $this->makeDtoWithUnionTypes([ 'reference' => [ 'slogan' => $faker->sentence(4) ] ]);
         $this->assertTrue(isset($dtoF->reference), 'Reference not set (g: array -> Organisation)');
         $this->assertInstanceOf(Organisation::class, $dtoF->reference);
     }

--- a/tests/Integration/Dto/ResolveDtoUnionTypesTest.php
+++ b/tests/Integration/Dto/ResolveDtoUnionTypesTest.php
@@ -34,10 +34,19 @@ class ResolveDtoUnionTypesTest extends DtoTestCase
         $dtoE = $this->makeDtoWithUnionTypes([ 'id' => null ]);
 
         $this->assertTrue(isset($dtoA->id), 'Id not set (a: string)');
+        $this->assertIsString($dtoA->id);
+
         $this->assertTrue(isset($dtoB->id), 'Id not set (b: int)');
+        $this->assertIsInt($dtoB->id);
+
         $this->assertTrue(isset($dtoC->id), 'Id not set (c: float)');
+        $this->assertIsFloat($dtoC->id);
+
         $this->assertTrue(isset($dtoD->id), 'Id not set (d: bool)');
+        $this->assertIsBool($dtoD->id);
+
         $this->assertFalse(isset($dtoE->id), 'Id set (c: null), but should be null');
+        $this->assertNull($dtoE->id);
     }
 
     /**

--- a/tests/Integration/Dto/ResolveDtoUnionTypesTest.php
+++ b/tests/Integration/Dto/ResolveDtoUnionTypesTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Aedart\Tests\Integration\Dto;
+
+use Aedart\Tests\Helpers\Dummies\Dto\Organisation;
+use Aedart\Tests\Helpers\Dummies\Dto\Person;
+use Aedart\Tests\TestCases\Dto\DtoTestCase;
+use TypeError;
+
+/**
+ * ResolveDtoUnionTypesTest
+ *
+ * @group dto
+ * @group dto-union-types
+ *
+ * @author Alin Eugen Deac <aedart@gmail.com>
+ * @package Aedart\Tests\Integration\Dto
+ */
+class ResolveDtoUnionTypesTest extends DtoTestCase
+{
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function resolvesScalarTypes()
+    {
+        $faker = $this->getFaker();
+
+        $dtoA = $this->makeDtoWithUnionTypes([ 'id' => (string) $faker->randomDigitNotNull() ]);
+        $dtoB = $this->makeDtoWithUnionTypes([ 'id' => $faker->randomDigitNotNull() ]);
+        $dtoC = $this->makeDtoWithUnionTypes([ 'id' => $faker->randomFloat() ]);
+        $dtoD = $this->makeDtoWithUnionTypes([ 'id' => $faker->boolean() ]);
+        $dtoE = $this->makeDtoWithUnionTypes([ 'id' => null ]);
+
+        $this->assertTrue(isset($dtoA->id), 'Id not set (a: string)');
+        $this->assertTrue(isset($dtoB->id), 'Id not set (b: int)');
+        $this->assertTrue(isset($dtoC->id), 'Id not set (c: float)');
+        $this->assertTrue(isset($dtoD->id), 'Id not set (d: bool)');
+        $this->assertFalse(isset($dtoE->id), 'Id set (c: null), but should be null');
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function resolvesArrayType()
+    {
+        $faker = $this->getFaker();
+
+        $dtoA = $this->makeDtoWithUnionTypes([ 'data' => $faker->words(3, true) ]);
+        $dtoB = $this->makeDtoWithUnionTypes([ 'data' => $faker->words(3) ]);
+        $dtoC = $this->makeDtoWithUnionTypes([ 'data' => null ]);
+
+        $this->assertTrue(isset($dtoA->data), 'Data not set (a: string)');
+        $this->assertTrue(isset($dtoB->data), 'Data not set (a: array)');
+        $this->assertFalse(isset($dtoC->data), 'Data set (b: null), but should be null');
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function resolvesObjectType()
+    {
+        $faker = $this->getFaker();
+
+        $dtoA = $this->makeDtoWithUnionTypes([ 'reference' => $faker->words(3, true) ]);
+        $dtoB = $this->makeDtoWithUnionTypes([ 'reference' => Person::makeNew([ 'name' => $faker->name() ]) ]);
+        $dtoC = $this->makeDtoWithUnionTypes([ 'reference' => [ 'name' => $faker->name() ] ]);
+        $dtoD = $this->makeDtoWithUnionTypes([ 'reference' => Organisation::makeNew( ['name' => $faker->company(), 'slogan' => $faker->sentence(4) ] ) ]);
+        $dtoE = $this->makeDtoWithUnionTypes([ 'reference' => [ 'name' => $faker->company(), 'slogan' => $faker->sentence(4) ] ]);
+        $dtoF = $this->makeDtoWithUnionTypes([ 'reference' => [ 'slogan' => $faker->sentence(4) ] ]);
+
+        $this->assertTrue(isset($dtoA->reference), 'Reference not set (a: string)');
+
+        // Note: both person and organisation have key "name", but since person is defined first,
+        // we expect it to be populated
+        $this->assertTrue(isset($dtoB->reference), 'Reference not set (b: Person)');
+        $this->assertTrue(isset($dtoC->reference), 'Reference not set (c: array -> Person)');
+        $this->assertInstanceOf(Person::class, $dtoC->reference);
+
+        // Note: given array data matches the keys of Organisation and not Person, which is what we expect!
+        $this->assertTrue(isset($dtoD->reference), 'Reference not set (d: Organisation)');
+        $this->assertTrue(isset($dtoE->reference), 'Reference not set (e: array -> Organisation)');
+        $this->assertInstanceOf(Organisation::class, $dtoE->reference);
+
+        // Note: keys only match properties in Organisation
+        $this->assertTrue(isset($dtoF->reference), 'Reference not set (g: array -> Organisation)');
+        $this->assertInstanceOf(Organisation::class, $dtoF->reference);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function failsWhenUnableToResolveType()
+    {
+        $this->expectException(TypeError::class);
+
+        $this->makeDtoWithUnionTypes([ 'reference' => [1, 2, 3] ]);
+    }
+}

--- a/tests/Integration/Dto/ResolveDtoUnionTypesTest.php
+++ b/tests/Integration/Dto/ResolveDtoUnionTypesTest.php
@@ -98,7 +98,7 @@ class ResolveDtoUnionTypesTest extends DtoTestCase
 
         // Note: keys only match properties in Organisation
         $dtoF = $this->makeDtoWithUnionTypes([ 'reference' => [ 'slogan' => $faker->sentence(4) ] ]);
-        $this->assertTrue(isset($dtoF->reference), 'Reference not set (g: array -> Organisation)');
+        $this->assertTrue(isset($dtoF->reference), 'Reference not set (f: array -> Organisation)');
         $this->assertInstanceOf(Organisation::class, $dtoF->reference);
     }
 

--- a/tests/TestCases/Dto/DtoTestCase.php
+++ b/tests/TestCases/Dto/DtoTestCase.php
@@ -5,6 +5,7 @@ namespace Aedart\Tests\TestCases\Dto;
 use Aedart\Testing\TestCases\IntegrationTestCase;
 use Aedart\Tests\Helpers\Dummies\Dto\Organisation;
 use Aedart\Tests\Helpers\Dummies\Dto\Person;
+use Aedart\Tests\Helpers\Dummies\Dto\Record;
 use Carbon\Carbon;
 
 /**
@@ -27,7 +28,7 @@ abstract class DtoTestCase extends IntegrationTestCase
      *
      * @throws \Throwable
      */
-    public function makeDto(array $data = [])
+    public function makeDto(array $data = []): Person
     {
         return Person::makeNew($data);
     }
@@ -39,9 +40,21 @@ abstract class DtoTestCase extends IntegrationTestCase
      *
      * @return Organisation
      */
-    public function makeArrayDto(array $data = [])
+    public function makeArrayDto(array $data = []): Organisation
     {
         return Organisation::makeNew($data);
+    }
+
+    /**
+     * Returns new Dto instance that declares some setters with union types
+     *
+     * @param  array  $data  [optional]
+     *
+     * @return Record
+     */
+    public function makeDtoWithUnionTypes(array $data = []): Record
+    {
+        return Record::makeNew($data);
     }
 
     /*****************************************************************

--- a/tests/TestCases/Dto/DtoTestCase.php
+++ b/tests/TestCases/Dto/DtoTestCase.php
@@ -3,6 +3,7 @@
 namespace Aedart\Tests\TestCases\Dto;
 
 use Aedart\Testing\TestCases\IntegrationTestCase;
+use Aedart\Tests\Helpers\Dummies\Dto\Article;
 use Aedart\Tests\Helpers\Dummies\Dto\Organisation;
 use Aedart\Tests\Helpers\Dummies\Dto\Person;
 use Aedart\Tests\Helpers\Dummies\Dto\Record;
@@ -55,6 +56,19 @@ abstract class DtoTestCase extends IntegrationTestCase
     public function makeDtoWithUnionTypes(array $data = []): Record
     {
         return Record::makeNew($data);
+    }
+
+    /**
+     * Returns new Array Dto instance that declares union types as allowed
+     * properties
+     *
+     * @param  array  $data  [optional]
+     *
+     * @return Article
+     */
+    public function makeArrayDtoWithUnionTypes(array $data = []): Article
+    {
+        return Article::makeNew($data);
     }
 
     /*****************************************************************

--- a/tests/Unit/Utils/JsonTest.php
+++ b/tests/Unit/Utils/JsonTest.php
@@ -64,4 +64,28 @@ class JsonTest extends UnitTestCase
 
         Json::decode($json);
     }
+
+    /**
+     * @test
+     *
+     * @return void
+     *
+     * @throws JsonException
+     */
+    public function canDetermineIfValidJsonEncoded()
+    {
+        $validA = Json::encode('abc');
+        $validB = '{ "name": "Sven" }';
+
+        $invalidA = [];
+        $invalidB = 'not_json_encoded';
+        $invalidC = '{ "name": "Sven"';
+
+        $this->assertTrue(Json::isValid($validA), 'should be valid');
+        $this->assertTrue(Json::isValid($validB), 'well formed string should be valid');
+
+        $this->assertFalse(Json::isValid($invalidA), 'array value should not be valid json!');
+        $this->assertFalse(Json::isValid($invalidB), 'Pure string should not be valid json');
+        $this->assertFalse(Json::isValid($invalidC), 'Malformed string should not be valid json');
+    }
 }


### PR DESCRIPTION
PR adds support for resolving union type arguments. The `ArrayDto` now also accepts specifying union types in its `$allowed` property.

See #82. 