### PR TITLE
Improve types in audit pkg

### DIFF
--- a/packages/Audit/src/Events/MultipleModelsChanged.php
+++ b/packages/Audit/src/Events/MultipleModelsChanged.php
@@ -6,9 +6,9 @@ use Aedart\Audit\Events\Concerns;
 use Aedart\Contracts\Audit\Types;
 use DateTimeInterface;
 use Illuminate\Contracts\Auth\Authenticatable;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use RuntimeException;
 use Throwable;
 
@@ -55,9 +55,9 @@ class MultipleModelsChanged
         array|Collection $models,
         Model|Authenticatable|null $user,
         string $type = Types::UPDATED,
-        ?array $original = null,
-        ?array $changed = null,
-        ?string $message = null,
+        array|null $original = null,
+        array|null $changed = null,
+        string|null $message = null,
         DateTimeInterface|Carbon|string|null $performedAt = null
     )
     {

--- a/packages/Audit/src/Models/Concerns/AuditTrailConfiguration.php
+++ b/packages/Audit/src/Models/Concerns/AuditTrailConfiguration.php
@@ -24,7 +24,7 @@ trait AuditTrailConfiguration
      */
     public function auditTrailModel(): string
     {
-        return $this->getConfig()->get('audit-trail.models.audit_trail');
+        return $this->getConfig()->get('audit-trail.models.audit_trail', AuditTrail::class);
     }
 
     /**
@@ -44,7 +44,7 @@ trait AuditTrailConfiguration
      */
     public function auditTrailUserModel(): string
     {
-        return $this->getConfig()->get('audit-trail.models.user');
+        return $this->getConfig()->get('audit-trail.models.user', \App\Models\User::class);
     }
 
     /**
@@ -71,7 +71,7 @@ trait AuditTrailConfiguration
      */
     public function auditTrailTable(): string
     {
-        return $this->getConfig()->get('audit-trail.table');
+        return $this->getConfig()->get('audit-trail.table', 'audit_trails');
     }
 
     /**
@@ -81,6 +81,6 @@ trait AuditTrailConfiguration
      */
     public function auditTableAttributesColumnType(): string
     {
-        return $this->getConfig()->get('audit-trail.attributes_column_type');
+        return $this->getConfig()->get('audit-trail.attributes_column_type', 'json');
     }
 }

--- a/packages/Audit/src/Observers/Concerns/ModelChangedEvents.php
+++ b/packages/Audit/src/Observers/Concerns/ModelChangedEvents.php
@@ -8,8 +8,8 @@ use Aedart\Audit\Events\MultipleModelsChanged;
 use Aedart\Support\Helpers\Auth\AuthTrait;
 use Aedart\Support\Helpers\Events\DispatcherTrait;
 use Illuminate\Contracts\Auth\Authenticatable;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 use Throwable;
 
 /**
@@ -35,9 +35,9 @@ trait ModelChangedEvents
      *
      * @throws Throwable
      */
-    public function dispatchModelChanged(Model $model, string $type, ?string $message = null): static
+    public function dispatchModelChanged(Model $model, string $type, string|null $message = null): static
     {
-        // Abort if model does not wish to record it's next change
+        // Abort if model does not wish to record its next change
         if (method_exists($model, 'mustRecordNextChange') && !$model->mustRecordNextChange()) {
             return $this;
         }
@@ -52,7 +52,7 @@ trait ModelChangedEvents
     /**
      * Dispatches multiple models changed event
      *
-     * @param Collection<Model>|Model[] $models The changed models
+     * @param  Collection<Model>|Model[]  $models The changed models
      * @param string $type [optional] The event type
      * @param array|null $original [optional] Original data (attributes) before change occurred.
      *                                        Default's to given model's original data, if none given.
@@ -65,12 +65,18 @@ trait ModelChangedEvents
      * @throws Throwable
      */
     public function dispatchMultipleModelsChanged(
-        $models,
+        array|Collection $models,
         string $type,
-        ?array $original = null,
-        ?array $changed = null,
-        ?string $message = null
-    ) {
+        array|null $original = null,
+        array|null $changed = null,
+        string|null $message = null
+    ): static
+    {
+        // Resolve models argument
+        if (!($models instanceof Collection)) {
+            $models = collect($models);
+        }
+
         // Determine if event dispatching should be aborted, based on first model's
         // "must record next change" state.
         $first = $models->first();
@@ -121,22 +127,24 @@ trait ModelChangedEvents
     /**
      * Creates a new "multiple models changed" event
      *
-     * @param Collection<Model>|Model[] $models The changed models
-     * @param string $type [optional] The event type
-     * @param array|null $original [optional] Original data (attributes) before change occurred.
+     * @param  Collection<Model>|Model[]  $models  The changed models
+     * @param  string  $type  [optional] The event type
+     * @param  array|null  $original  [optional] Original data (attributes) before change occurred.
      *                                        Default's to given model's original data, if none given.
-     * @param array|null $changed [optional] Changed data (attributes) after change occurred.
+     * @param  array|null  $changed  [optional] Changed data (attributes) after change occurred.
      *                                        Default's to given model's changed data, if none given.
-     * @param string|null $message [optional] Eventual user provided message associated with the event
+     * @param  string|null  $message  [optional] Eventual user provided message associated with the event
      *
      * @return MultipleModelsChanged
+     *
+     * @throws Throwable
      */
     public function makeMultipleModelsChangedEvent(
-        $models,
+        array|Collection $models,
         string $type,
-        ?array $original = null,
-        ?array $changed = null,
-        ?string $message = null
+        array|null $original = null,
+        array|null $changed = null,
+        string|null $message = null
     ): MultipleModelsChanged
     {
         return new MultipleModelsChanged(

--- a/packages/Audit/src/Subscribers/AuditTrailEventSubscriber.php
+++ b/packages/Audit/src/Subscribers/AuditTrailEventSubscriber.php
@@ -28,15 +28,10 @@ class AuditTrailEventSubscriber
      */
     public function subscribe(Dispatcher $dispatcher)
     {
-        // TODO: This can safely be removed in next major version
-        // To ensure that we keep backwards compatibility, we load evt. custom listener that has
-        // been specified.
-        $recordSingleEntryListener = $this->getConfig()->get('audit-trail.listener', RecordAuditTrailEntry::class);
-
         // Handle change event for a single model
         $dispatcher->listen(
             ModelHasChanged::class,
-            [$recordSingleEntryListener, 'handle']
+            [RecordAuditTrailEntry::class, 'handle']
         );
 
         // Handle multiple models changed event

--- a/packages/Audit/src/Traits/RecordsChanges.php
+++ b/packages/Audit/src/Traits/RecordsChanges.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Facades\Config;
 /**
  * Records Changes
  *
- * Intended to be used by models that must keep an audit trail of it's
+ * Intended to be used by models that must keep an audit trail of its
  * changes.
  *
  * @property-read AuditTrail[]|Collection $recordedChanges Audit trail entries for this model


### PR DESCRIPTION
Minor improvements to types in the audit trail package. Also resolved an issues where the PHPDoc claimed to accept an arrya og models, but code excpected an collection of models, in `dispatchMultipleModelsChanged()` method.

See #100 