### PR TITLE
Fix filters

### DIFF
--- a/packages/Database/src/Models/Concerns/Filtering.php
+++ b/packages/Database/src/Models/Concerns/Filtering.php
@@ -35,23 +35,18 @@ trait Filtering
     public function scopeApplyFilters(Builder|EloquentBuilder $query, Criteria|array $filters = []): Builder|EloquentBuilder
     {
         if (!is_array($filters)) {
-            $filters = [$filters];
+            $filters = [ $filters ];
         }
 
-        // Apply filters in a logical group, so that they do not mess with
-        // evt. already applied criteria and expressions.
-
-        $query->where(function ($query) use ($filters) {
-            foreach ($filters as $filter) {
-                // Skip if filter is not applicable
-                if (!$filter->isApplicable($query, $filters)) {
-                    continue;
-                }
-
-                // Apply scope
-                $query = $filter->apply($query);
+        foreach ($filters as $filter) {
+            // Skip if filter is not applicable
+            if (!$filter->isApplicable($query, $filters)) {
+                continue;
             }
-        });
+
+            // Apply scope
+            $query = $filter->apply($query);
+        }
 
         return $query;
     }

--- a/packages/Filters/src/Processors/ConstraintsProcessor.php
+++ b/packages/Filters/src/Processors/ConstraintsProcessor.php
@@ -227,9 +227,10 @@ class ConstraintsProcessor extends BaseProcessor
                 return $filter::make($column, $operator, $value, $logical);
             }
 
-            // (Re)-configure if instance was provided
+            // When an instance is provided, then it must be cloned and
+            // configured with field name, operator, value,...etc
             if ($filter instanceof FieldCriteria) {
-                return $filter
+                return (clone $filter)
                     ->setField($column)
                     ->setOperator($operator)
                     ->setLogical($logical)

--- a/packages/Filters/src/Query/Filters/Fields/BelongsToFilter.php
+++ b/packages/Filters/src/Query/Filters/Fields/BelongsToFilter.php
@@ -97,11 +97,10 @@ class BelongsToFilter extends BaseFieldFilter
 
         // Determine the type of relation that the constraint must be built
         // for. E.g. use "whereHas" or "whereHasMorph" constraint.
-        $isMorph = false;
+
+        /** @var \Illuminate\Database\Eloquent\Relations\BelongsTo|\Illuminate\Database\Eloquent\Relations\MorphTo $relationInstance */
         $relationInstance = $model->{$relation}();
-        if ($relationInstance instanceof MorphTo) {
-            $isMorph = true;
-        }
+        $isMorph = ($relationInstance instanceof MorphTo);
 
         // Extract relation field.
         $relationField = $this->extractRelationField($this->field());

--- a/packages/Filters/src/Query/Filters/Fields/BelongsToFilter.php
+++ b/packages/Filters/src/Query/Filters/Fields/BelongsToFilter.php
@@ -259,7 +259,7 @@ class BelongsToFilter extends BaseFieldFilter
             return;
         }
 
-        // Allow list of numeric values...
+        // Allow list of numeric or string values...
         if (in_array($operator, [ 'in', 'not_in' ]) && Str::contains($value, ',')) {
             $values = $this->valueToList($value);
 

--- a/packages/Filters/src/Query/Filters/Fields/BelongsToFilter.php
+++ b/packages/Filters/src/Query/Filters/Fields/BelongsToFilter.php
@@ -98,7 +98,7 @@ class BelongsToFilter extends BaseFieldFilter
         // Determine the type of relation that the constraint must be built
         // for. E.g. use "whereHas" or "whereHasMorph" constraint.
         $isMorph = false;
-        $relationInstance = $model->{$relation};
+        $relationInstance = $model->{$relation}();
         if ($relationInstance instanceof MorphTo) {
             $isMorph = true;
         }

--- a/tests/Helpers/Dummies/Database/Models/Category.php
+++ b/tests/Helpers/Dummies/Database/Models/Category.php
@@ -5,6 +5,8 @@ namespace Aedart\Tests\Helpers\Dummies\Database\Models;
 use Aedart\Contracts\Database\Models\Sluggable;
 use Aedart\Database\Model;
 use Aedart\Database\Models\Concerns;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 
@@ -21,12 +23,16 @@ use Illuminate\Support\Carbon;
  * @property Carbon $updated_at Date and time of when record was last updated
  * @property Carbon|null $deleted_at Evt. date and time of when record was soft-deleted
  *
+ * @property-read Owner[]|Collection<Owner> $owners Category owners
+ * @property-read Product[]|Collection<Product> $products Products in this category
+ *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Tests\Helpers\Dummies\Database\Models
  */
 class Category extends Model implements Sluggable
 {
     use Concerns\Slugs;
+    use Concerns\Filtering;
     use SoftDeletes;
 
     /**
@@ -35,4 +41,24 @@ class Category extends Model implements Sluggable
      * @var string[]|bool
      */
     protected $guarded = ['id'];
+
+    /**
+     * Category owners
+     *
+     * @return HasMany
+     */
+    public function owners(): HasMany
+    {
+        return $this->hasMany(Owner::class, 'category_id');
+    }
+
+    /**
+     * Products in this category
+     *
+     * @return HasMany
+     */
+    public function products(): HasMany
+    {
+        return $this->hasMany(Product::class, 'category_id');
+    }
 }

--- a/tests/Helpers/Dummies/Database/Models/Owner.php
+++ b/tests/Helpers/Dummies/Database/Models/Owner.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @property int $id Unique identifier
  * @property string $name Name of owner
- * @property int $category_id Foreign key
+ * @property int|null $category_id Foreign key
  *
  * @property-read Category|null $category
  *

--- a/tests/Helpers/Dummies/Database/Models/Product.php
+++ b/tests/Helpers/Dummies/Database/Models/Product.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Aedart\Tests\Helpers\Dummies\Database\Models;
+
+use Aedart\Database\Model;
+use Aedart\Database\Models\Concerns\Filtering;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
+
+/**
+ * Product
+ *
+ * @property int $id Product id
+ * @property int|null $category_id Foreign key - category this product belongs to
+ * @property string $name Name of product
+ * @property string|null $description Evt. description of product
+ * @property int|null $restricted_to_owner_id Foreign key - product is restricted to given owner
+ * @property Carbon $created_at Date and time of when record was created
+ * @property Carbon $updated_at Date and time of when record was last updated
+ * @property Carbon|null $deleted_at Evt. date and time of when record was soft-deleted
+ *
+ * @property-read Category|null $category The category this product belongs to
+ * @property-read Owner|null $restrictedOwner Owner restriction
+ *
+ * @author Alin Eugen Deac <ade@rspsystems.com>
+ * @package Aedart\Tests\Helpers\Dummies\Database\Models
+ */
+class Product extends Model
+{
+    use Filtering;
+    use SoftDeletes;
+
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var string[]|bool
+     */
+    protected $guarded = ['id'];
+
+    /**
+     * The category this product belongs to
+     *
+     * @return BelongsTo
+     */
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class, 'category_id');
+    }
+
+    /**
+     * Owner restriction
+     *
+     * @return BelongsTo
+     */
+    public function restrictedOwner(): BelongsTo
+    {
+        return $this->belongsTo(Owner::class, 'restricted_to_owner_id');
+    }
+}


### PR DESCRIPTION
Prevents overwrite of existing filter instance, in the `ConstraintsProcessor`.

## Details

A small, but very difficult to spot issue was the main cause of #117. The logical grouping, which was mentioned _should not_ be required at all, because that is automatically handled as intended.

## References

#117 