### PR TITLE
Fix driver key not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.5.2] - 2022-11-13
+
+### Fixed
+
+* `ErrorException` Undefined array key "driver". [#123](https://github.com/aedart/athenaeum/issues/123).
+
+This defect was introduced by `orchestra/testbench`, from ` v7.12.0`, in which the "testing" database connection configuration was removed.
+Several tests assumed that a "testing" connection was available and attempted to use it.
+A custom `TestingConnection` util class now ensures such a connection exists for affected tests.
+
 ## [6.5.1] - 2022-11-04
 
 ### Fixed

--- a/packages/Testing/src/Laravel/Database/TestingConnection.php
+++ b/packages/Testing/src/Laravel/Database/TestingConnection.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Aedart\Testing\Laravel\Database;
+
+use Illuminate\Support\Facades\Config;
+
+/**
+ * Testing Connection
+ *
+ * @author Alin Eugen Deac <aedart@gmail.com>
+ * @package Aedart\Testing\Laravel\Database
+ */
+class TestingConnection
+{
+    /**
+     * Adds and enables a "testing" database connection (by default, a sqlite in-memory connection)
+     *
+     * @param  string  $name  [optional]
+     * @param  array  $options  [optional]
+     *
+     * @return void
+     */
+    public static function enableConnection(string $name = 'testing', array $options = []): void
+    {
+        $options = array_merge(
+            static::defaultConnectionOptions(),
+            $options
+        );
+
+        Config::set("database.connections.{$name}", $options);
+
+        Config::set('database.default', $name);
+    }
+
+    /**
+     * Default "testing" connection options
+     *
+     * @return array
+     */
+    public static function defaultConnectionOptions(): array
+    {
+        return [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'foreign_key_constraints' => true,
+        ];
+    }
+}

--- a/tests/TestCases/Acl/AclTestCase.php
+++ b/tests/TestCases/Acl/AclTestCase.php
@@ -10,10 +10,12 @@ use Aedart\Acl\Traits\RegistrarTrait;
 use Aedart\Config\Providers\ConfigLoaderServiceProvider;
 use Aedart\Config\Traits\ConfigLoaderTrait;
 use Aedart\Support\Helpers\Auth\Access\GateTrait;
+use Aedart\Testing\Laravel\Database\TestingConnection;
 use Aedart\Testing\TestCases\LaravelTestCase;
 use Aedart\Tests\Helpers\Dummies\Acl\User;
 use Codeception\Configuration;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Hash;
 
 /**
@@ -66,10 +68,7 @@ abstract class AclTestCase extends LaravelTestCase
      */
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('database.default', 'testing');
-
-        // Enable foreign key constraints for SQLite testing database
-        $app['config']->set('database.connections.testing.foreign_key_constraints', true);
+        TestingConnection::enableConnection();
     }
 
     /*****************************************************************

--- a/tests/TestCases/Audit/AuditTestCase.php
+++ b/tests/TestCases/Audit/AuditTestCase.php
@@ -5,6 +5,7 @@ namespace Aedart\Tests\TestCases\Audit;
 use Aedart\Audit\Providers\AuditTrailServiceProvider;
 use Aedart\Config\Providers\ConfigLoaderServiceProvider;
 use Aedart\Config\Traits\ConfigLoaderTrait;
+use Aedart\Testing\Laravel\Database\TestingConnection;
 use Aedart\Testing\TestCases\LaravelTestCase;
 use Aedart\Tests\Helpers\Dummies\Audit\Category;
 use Aedart\Tests\Helpers\Dummies\Audit\User;
@@ -55,10 +56,7 @@ abstract class AuditTestCase extends LaravelTestCase
      */
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('database.default', 'testing');
-
-        // Enable foreign key constraints for SQLite testing database
-        $app['config']->set('database.connections.testing.foreign_key_constraints', true);
+        TestingConnection::enableConnection();
     }
 
     /*****************************************************************

--- a/tests/TestCases/Database/DatabaseTestCase.php
+++ b/tests/TestCases/Database/DatabaseTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Aedart\Tests\TestCases\Database;
 
+use Aedart\Testing\Laravel\Database\TestingConnection;
 use Aedart\Testing\TestCases\LaravelTestCase;
 
 /**
@@ -31,10 +32,7 @@ abstract class DatabaseTestCase extends LaravelTestCase
      */
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('database.default', 'testing');
-
-        // Enable foreign key constraints for SQLite testing database
-        $app['config']->set('database.connections.testing.foreign_key_constraints', true);
+        TestingConnection::enableConnection();
     }
 
     /*****************************************************************

--- a/tests/TestCases/Flysystem/Db/FlysystemDbTestCase.php
+++ b/tests/TestCases/Flysystem/Db/FlysystemDbTestCase.php
@@ -6,6 +6,7 @@ use Aedart\Contracts\Flysystem\Db\RecordTypes;
 use Aedart\Flysystem\Db\Adapters\DatabaseAdapter;
 use Aedart\Flysystem\Db\Providers\FlysystemDatabaseAdapterServiceProvider;
 use Aedart\Support\Helpers\Filesystem\FileTrait;
+use Aedart\Testing\Laravel\Database\TestingConnection;
 use Aedart\Tests\TestCases\Flysystem\FlysystemTestCase;
 use Codeception\Configuration;
 use Illuminate\Support\Collection;
@@ -74,11 +75,7 @@ abstract class FlysystemDbTestCase extends FlysystemTestCase
      */
     protected function getEnvironmentSetUp($app)
     {
-        // For these tests we will run against a sqlite in-memory database,
-        // so that we can safely clean up everything afterwards.
-        // NOTE: Configuration from orchestra test bench-core is used here!
-        $app['config']->set('database.default', 'testing');
-        $app['config']->set('database.connections.testing.foreign_key_constraints', true);
+        TestingConnection::enableConnection();
     }
 
     /**

--- a/tests/TestCases/Http/ApiResourcesTestCase.php
+++ b/tests/TestCases/Http/ApiResourcesTestCase.php
@@ -9,6 +9,7 @@ use Aedart\Contracts\Config\Parsers\Exceptions\FileParserException;
 use Aedart\Http\Api\Providers\ApiResourceServiceProvider;
 use Aedart\Http\Api\Traits\ApiResourceRegistrarTrait;
 use Aedart\Support\Helpers\Config\ConfigTrait;
+use Aedart\Testing\Laravel\Database\TestingConnection;
 use Aedart\Testing\TestCases\LaravelTestCase;
 use Aedart\Validation\Providers\ValidationServiceProvider;
 use Codeception\Configuration;
@@ -81,10 +82,7 @@ abstract class ApiResourcesTestCase extends LaravelTestCase
      */
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('database.default', 'testing');
-
-        // Enable foreign key constraints for SQLite testing database
-        $app['config']->set('database.connections.testing.foreign_key_constraints', true);
+        TestingConnection::enableConnection();
     }
 
     /*****************************************************************


### PR DESCRIPTION
Fix #123 

## Details

Introduced a new `TestingConnection` util that enables a "testing" connection, rather than relying on one being available.
