### PR TITLE
Add support for checksum, in Database Adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* The `DatabaseAdapter` now supports League's [checksum](https://flysystem.thephpleague.com/docs/usage/checksums/) operation.
+
 ### Removed
 
 * `throw` option for flysystem database connection. This option was never used.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+* `throw` option for flysystem database connection. This option was never used.
+
 ## [6.6.0] - 2022-11-28
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "illuminate/pipeline": "^v9.30.1",
         "illuminate/support": "^v9.30.1",
         "illuminate/validation": "^v9.30.1",
-        "league/flysystem": "^3.5.0",
+        "league/flysystem": "^3.11.0",
         "mockery/mockery": "1.5.*",
         "psr/http-client": "^1.0.1",
         "psr/http-factory": "^1.0.1",

--- a/packages/Flysystem/Db/composer.json
+++ b/packages/Flysystem/Db/composer.json
@@ -17,7 +17,7 @@
         "aedart/athenaeum-database": "^6.7",
         "aedart/athenaeum-streams": "^6.7",
         "illuminate/console": "^v9.30.1",
-        "league/flysystem": "^3.5.0"
+        "league/flysystem": "^3.11.0"
     },
     "require-dev": {
         "league/flysystem-adapter-test-utilities": "^3.3.0"

--- a/packages/Flysystem/Db/configs/example-filesystem.php
+++ b/packages/Flysystem/Db/configs/example-filesystem.php
@@ -25,7 +25,6 @@ return [
             'contents_table' => 'files_contents',
             'hash_algo' => 'sha256',
             'path_prefix' => '',
-            'throw' => true
         ]
     ],
 

--- a/packages/Flysystem/Db/src/Adapters/Concerns/Hashing.php
+++ b/packages/Flysystem/Db/src/Adapters/Concerns/Hashing.php
@@ -55,7 +55,10 @@ trait Hashing
      *
      * If "hash" is given via `$config`, then that value is returned.
      * Otherwise, the stream content is hashed using adapter's specified
-     * hashing algorithm
+     * hashing algorithm.
+     *
+     * NOTE: If the config contains a `checksum_algo` (League's default option),
+     * then this hashing algorithm will be used instead of this adapter's default.
      *
      * @see setHashAlgorithm
      * @see getHashAlgorithm
@@ -76,6 +79,8 @@ trait Hashing
             return $hash;
         }
 
-        return $stream->hash($this->getHashAlgorithm());
+        $algo = $config->get('checksum_algo', $this->getHashAlgorithm());
+
+        return $stream->hash($algo);
     }
 }

--- a/packages/Flysystem/Db/src/Console/MakeAdapterMigrationCommand.php
+++ b/packages/Flysystem/Db/src/Console/MakeAdapterMigrationCommand.php
@@ -74,7 +74,6 @@ Example:
         'contents_table' => '{$contentsTable}',
         'hash_algo' => 'sha256',
         'path_prefix' => '',
-        'throw' => true
     ]
 ],
 EOF,

--- a/packages/Flysystem/Db/src/Providers/FlysystemDatabaseAdapterServiceProvider.php
+++ b/packages/Flysystem/Db/src/Providers/FlysystemDatabaseAdapterServiceProvider.php
@@ -49,17 +49,23 @@ class FlysystemDatabaseAdapterServiceProvider extends ServiceProvider
                 ->getConnectionResolver()
                 ->connection(data_get($settings, 'connection', 'mysql'));
 
+            // Obtain hashing / checksum algorithm
+            $algo = data_get($settings, 'hash_algo', 'sha256');
+
             // Create and configure adapter
             $adapter = (new DatabaseAdapter(
                 data_get($settings, 'files_table', 'files'),
                 data_get($settings, 'contents_table', 'files_contents'),
                 $connection,
             ))
-                ->setHashAlgorithm(data_get($settings, 'hash_algo', 'sha256'))
+                ->setHashAlgorithm($algo)
                 ->setPathPrefix(data_get($settings, 'path_prefix', ''));
 
             return new FilesystemAdapter(
-                new Filesystem($adapter),
+                new Filesystem(
+                    adapter: $adapter,
+                    config: [ 'checksum_algo' => $algo ]
+                ),
                 $adapter,
                 $settings
             );

--- a/tests/Integration/Flysystem/Db/Adapters/F0_ChecksumTest.php
+++ b/tests/Integration/Flysystem/Db/Adapters/F0_ChecksumTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Aedart\Tests\Integration\Flysystem\Db\Adapters;
+
+use Aedart\Testing\Helpers\ConsoleDebugger;
+use Aedart\Tests\TestCases\Flysystem\Db\FlysystemDbTestCase;
+use League\Flysystem\FilesystemException;
+
+/**
+ * F0_ChecksumTest
+ *
+ * @group flysystem
+ * @group flysystem-db
+ * @group flysystem-db-f0
+ *
+ * @author Alin Eugen Deac <aedart@gmail.com>
+ * @package Aedart\Tests\Integration\Flysystem\Db\Adapters
+ */
+class F0_ChecksumTest extends FlysystemDbTestCase
+{
+    /**
+     * @test
+     *
+     * @return void
+     *
+     * @throws FilesystemException
+     */
+    public function canGetChecksumUsingCustomAlgo(): void
+    {
+        $path = 'home/books/october_falls.txt';
+        $content = $this->getFaker()->sentence();
+
+        // ----------------------------------------------------------------- //
+
+        $fs = $this->filesystem();
+        $fs->write($path, $content);
+
+        // ----------------------------------------------------------------- //
+
+        $algo = 'crc32';
+        $expected = hash($algo, $content);
+        $result = $fs->checksum($path, [ 'checksum_algo' => $algo ]);
+
+        ConsoleDebugger::output([
+            'expected' => $expected,
+            'actual' => $result
+        ]);
+
+        $this->assertSame($expected, $result);
+    }
+}

--- a/tests/Integration/Flysystem/Db/Adapters/League/DatabaseAdapterTest.php
+++ b/tests/Integration/Flysystem/Db/Adapters/League/DatabaseAdapterTest.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\Capsule\Manager;
 use Illuminate\Database\Migrations\Migration;
 use League\Flysystem\AdapterTestUtilities\FilesystemAdapterTestCase as BaseTestCase;
-use League\Flysystem\Config;
 use League\Flysystem\FilesystemAdapter;
 
 /**
@@ -138,5 +137,27 @@ class DatabaseAdapterTest extends BaseTestCase
         // because it could NOT obtain the "data provider"... This simple overwrite
         // somehow works...!?
         parent::writing_and_reading_files_with_special_path($path);
+    }
+
+    /**
+     * @test
+     * @inheritdoc
+     */
+    public function get_checksum(): void
+    {
+        // The original test always assumes a md5 checksum of a file. However, the database adapter
+        // might apply a different default hashing algorithm therefore, we change the adapter to
+        // fit the original test
+
+        /** @var DatabaseAdapter $adapter */
+        $adapter = $this->createFilesystemAdapter();
+        $adapter->setHashAlgorithm('md5');
+        $this->useAdapter($adapter);
+
+        // Invoke original test...
+        parent::get_checksum();
+
+        // Clear "custom" adapter...
+        $this->clearCustomAdapter();
     }
 }

--- a/tests/Integration/Flysystem/Db/Adapters/League/DatabaseAdapterTest.php
+++ b/tests/Integration/Flysystem/Db/Adapters/League/DatabaseAdapterTest.php
@@ -15,6 +15,7 @@ use League\Flysystem\FilesystemAdapter;
 /**
  * DatabaseAdapterTest
  *
+ * @group flysystem
  * @group flysystem-db
  * @group flysystem-db-league-tests
  *

--- a/tests/Integration/Flysystem/Db/Storage/StorageDiskTest.php
+++ b/tests/Integration/Flysystem/Db/Storage/StorageDiskTest.php
@@ -38,7 +38,6 @@ class StorageDiskTest extends FlysystemDbTestCase
             'contents_table' => 'file_contents',
             'hash_algo' => 'sha256',
             'path_prefix' => '',
-            'throw' => true
         ]);
     }
 


### PR DESCRIPTION
The Flysystem `DatabaseAdapter` has been changed to support League's [checksum](https://flysystem.thephpleague.com/docs/usage/checksums/).

See #121