### PR TITLE
[Etags] Fix type error when null received as http header value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.8.1] - 2023-01-19
+
+### Fixed
+
+* Type Error when attempting to parse etags collection from Http header value that was set to `null`, in `\Aedart\ETags\Mixins\RequestETagsMixin::etagsFrom()`.
+
 ## [6.8.0] - 2023-01-09
 
 ### Changed
@@ -897,7 +903,8 @@ It will highjack the `app` binding, which will cause your application to behave 
 
 * Please review commits on [GitHub](https://github.com/aedart/athenaeum/commits/master)
 
-[Unreleased]: https://github.com/aedart/athenaeum/compare/6.8.0...HEAD
+[Unreleased]: https://github.com/aedart/athenaeum/compare/6.8.1...HEAD
+[6.8.1]: https://github.com/aedart/athenaeum/compare/6.8.0...6.8.1
 [6.8.0]: https://github.com/aedart/athenaeum/compare/6.7.0...6.8.0
 [6.7.0]: https://github.com/aedart/athenaeum/compare/6.6.0...6.7.0
 [6.6.0]: https://github.com/aedart/athenaeum/compare/6.5.2...6.6.0

--- a/packages/ETags/src/Mixins/RequestETagsMixin.php
+++ b/packages/ETags/src/Mixins/RequestETagsMixin.php
@@ -5,6 +5,7 @@ namespace Aedart\ETags\Mixins;
 use Aedart\Contracts\ETags\Collection;
 use Aedart\Contracts\ETags\ETag;
 use Aedart\Contracts\ETags\Exceptions\ETagException;
+use Aedart\ETags\Exceptions\InvalidRawValue;
 use Aedart\ETags\Facades\Generator;
 use Closure;
 use DateTimeInterface;
@@ -34,7 +35,12 @@ class RequestETagsMixin
         return function(string $header): Collection
         {
             try {
-                return Generator::parse($this->header($header, ''));
+                $value = $this->header($header);
+                if (empty($value)) {
+                    $value = '';
+                }
+
+                return Generator::parse($value);
             } catch (ETagException $e) {
                 throw new BadRequestHttpException(sprintf('Invalid etag value(s) in %s header', $header), $e);
             }
@@ -135,7 +141,7 @@ class RequestETagsMixin
         return function(string $header): DateTimeInterface|null
         {
             $value = $this->header($header);
-            if (!isset($value)) {
+            if (empty($value)) {
                 return null;
             }
 

--- a/tests/Integration/ETags/Mixins/RequestETagsMixinTest.php
+++ b/tests/Integration/ETags/Mixins/RequestETagsMixinTest.php
@@ -70,6 +70,26 @@ class RequestETagsMixinTest extends ETagsTestCase
      *
      * @return void
      */
+    public function doesNotFailWhenNullEtagHeaderValueReceived(): void
+    {
+        // This is really an edge case, where somehow null is set as value
+        // for a header...
+        $request = Request::create('/test', 'GET', [], [], [], [
+            'HTTP_IF_MATCH' => null
+        ]);
+
+        /** @var Collection $ifMatchEtags */
+        $ifMatchEtags = $request->etagsFrom('If-Match');
+
+        $this->assertInstanceOf(Collection::class, $ifMatchEtags, 'If-Match etags not a collection');
+        $this->assertTrue($ifMatchEtags->isEmpty());
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
     public function failsWhenInvalidEtagValues(): void
     {
         $this->expectException(BadRequestHttpException::class);


### PR DESCRIPTION
When `null` is set as a http header value and attempted parsed as an Etags Collection, a Type Error is thrown, in `\Aedart\ETags\Mixins\RequestETagsMixin::etagsFrom`.

Typically, this only happened during testing where incorrect values might be set or generated for headers.

This PR fixes such an issue.
