### PR TITLE
Change default hashing algorithms to xxHash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `SortFilter` and `SortingProcessor` now support custom sorting callbacks.
 * `getResourceKeyName()` in `ApiResource` now throws `LogicException`, if unable to determine resource's identifier key name.
 * `hash()` method can now accept options for the specified hashing algorithm. [#106](https://github.com/aedart/athenaeum/issues/106)
+* Switched to [`xxHash`](https://php.watch/versions/8.1/xxHash) as default hashing algorithm in etags `BaseGenerator` and example configuration.
 * Temporary and public URL tests for database adapter are forced to evaluate to true. Original tests marked them as skipped, because features are not supported.
 * Extracted translation utilities into own trait in `BaseRule`, which now allow setting translation key prefix (_vendor prefix_). [#114](https://github.com/aedart/athenaeum/issues/114).
 * Extracted `$attribute` into own trait in `BaseRule`. Can now be set or obtained via appropriate getter and setter methods.

--- a/packages/ETags/configs/etags.php
+++ b/packages/ETags/configs/etags.php
@@ -27,10 +27,10 @@ return [
             'options' => [
 
                 // Hashing algorithm to be used for ETags flagged as "weak" (weak comparison)
-                'weak_algo' => 'crc32',
+                'weak_algo' => 'xxh3',
 
                 // Hashing algorithm to be used for ETags NOT flagged as "weak" (strong comparison)
-                'strong_algo' => 'sha1',
+                'strong_algo' => 'xxh128',
             ],
         ],
     ]

--- a/packages/ETags/src/Generators/BaseGenerator.php
+++ b/packages/ETags/src/Generators/BaseGenerator.php
@@ -22,13 +22,13 @@ abstract class BaseGenerator implements Generator
      * Default hashing algorithm for hashing content to be
      * used for weak comparison ETags
      */
-    protected const DEFAULT_WEAK_ALGO = 'crc32';
+    protected const DEFAULT_WEAK_ALGO = 'xxh3';
 
     /**
      * Default hashing algorithm for hashing content to be
      * used for strong comparison ETags
      */
-    protected const DEFAULT_STRONG_ALGO = 'sha256';
+    protected const DEFAULT_STRONG_ALGO = 'xxh128';
 
     /**
      * Create a new ETag Generator instance

--- a/tests/Integration/Flysystem/Db/Adapters/F0_ChecksumTest.php
+++ b/tests/Integration/Flysystem/Db/Adapters/F0_ChecksumTest.php
@@ -37,7 +37,7 @@ class F0_ChecksumTest extends FlysystemDbTestCase
 
         // ----------------------------------------------------------------- //
 
-        $algo = 'crc32';
+        $algo = 'xxh3';
         $expected = hash($algo, $content);
         $result = $fs->checksum($path, [ 'checksum_algo' => $algo ]);
 

--- a/tests/Integration/Streams/File/F0_HashingTest.php
+++ b/tests/Integration/Streams/File/F0_HashingTest.php
@@ -25,7 +25,7 @@ class F0_HashingTest extends StreamTestCase
      */
     public function canObtainHashOfStreamsContent()
     {
-        $algo = 'crc32';
+        $algo = 'xxh3';
         $data = $this->getFaker()->realText(50);
 
         $stream = FileStream::openTemporary('r+b', 25)

--- a/tests/_data/configs/etags/etags.php
+++ b/tests/_data/configs/etags/etags.php
@@ -27,17 +27,17 @@ return [
             'options' => [
 
                 // Algorithm intended for ETags flagged as "weak" (weak comparison)
-                'weak_algo' => 'crc32',
+                'weak_algo' => 'xxh3',
 
                 // Algorithm intended for ETags NOT flagged as "weak" (strong comparison)
-                'strong_algo' => 'sha1',
+                'strong_algo' => 'xxh128',
             ],
         ],
 
         'other' => [
             'driver' => \Aedart\ETags\Generators\GenericGenerator::class,
             'options' => [
-                'weak_algo' => 'md5',
+                'weak_algo' => 'crc32',
                 'strong_algo' => 'sha1',
             ],
         ]

--- a/tests/_data/configs/http/api/etags.php
+++ b/tests/_data/configs/http/api/etags.php
@@ -27,10 +27,10 @@ return [
             'options' => [
 
                 // Hashing algorithm to be used for ETags flagged as "weak" (weak comparison)
-                'weak_algo' => 'crc32',
+                'weak_algo' => 'xxh3',
 
                 // Hashing algorithm to be used for ETags NOT flagged as "weak" (strong comparison)
-                'strong_algo' => 'sha1',
+                'strong_algo' => 'xxh128',
             ],
         ],
     ]


### PR DESCRIPTION
Change default hashing algorithm to [`xxHash`](https://php.watch/versions/8.1/xxHash) for the etags `BaseGenerator` and example configuration.
