### PR TITLE
Add remove payload middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Query `Joins` concern, in the database package.
 * `Prefixing` concern, in the database package.
 * `BaseRule` can now set and obtain a `FailedState` (_a [`UnitEnum`](https://www.php.net/manual/en/class.unitenum.php)_), to allow handling of more complex error messages.
+* `RemoveResponsePayload` middleware in the Http Api package.
 * Test `Response` utility.
 
 ### Changed

--- a/packages/Http/Api/src/Middleware/RemoveResponsePayload.php
+++ b/packages/Http/Api/src/Middleware/RemoveResponsePayload.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Aedart\Http\Api\Middleware;
+
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Teapot\StatusCode\All as Status;
+
+/**
+ * Remove Response Payload Middleware
+ *
+ * @author Alin Eugen Deac <aedart@gmail.com>
+ * @package Aedart\Http\Api\Middleware
+ */
+class RemoveResponsePayload
+{
+    /**
+     * Converts response to "204 No Content" when a "no payload" query parameter
+     * is requested.
+     *
+     * Note: If the response is not successful, then it will not be converted.
+     *
+     * @param Request $request
+     * @param Closure $next
+     * @param string $key [optional] Name of query parameter
+     *
+     * @return JsonResponse|Response
+     */
+    public function handle(Request $request, Closure $next, string $key = 'no_payload')
+    {
+        /** @var Response|JsonResponse $response */
+        $response = $next($request);
+
+        if ($response->isSuccessful()
+            && $request->has($key)
+            && in_array($request->query($key, false), ['1', 'true', 1, true, 'on', 'yes'])
+        ) {
+            return $response
+                ->setStatusCode(Status::NO_CONTENT)
+                ->setContent(null);
+        }
+
+        return $response;
+    }
+}

--- a/tests/Integration/Http/Api/Middleware/RemoveResponsePayloadMiddlewareTest.php
+++ b/tests/Integration/Http/Api/Middleware/RemoveResponsePayloadMiddlewareTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Aedart\Tests\Integration\Http\Api\Middleware;
+
+use Aedart\Http\Api\Middleware\RemoveResponsePayload;
+use Aedart\Testing\Helpers\Http\Response;
+use Aedart\Tests\TestCases\Http\ApiResourcesTestCase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use JsonException;
+use Teapot\StatusCode\All as Status;
+
+/**
+ * RemoveResponsePayloadMiddlewareTest
+ *
+ * @group http-api
+ * @group http-api-middleware
+ * @group http-api-middleware-remove-payload
+ *
+ * @author Alin Eugen Deac <aedart@gmail.com>
+ * @package Aedart\Tests\Integration\Http\Api\Middleware
+ */
+class RemoveResponsePayloadMiddlewareTest extends ApiResourcesTestCase
+{
+    /**
+     * @test
+     *
+     * @return void
+     *
+     * @throws JsonException
+     */
+    public function convertsResponseToNoContent(): void
+    {
+        $key = 'nrp';
+        Route::patch('/games/{id}', function (Request $request) {
+            return response()->json([
+                'name' => $request->get('name', 'N/A')
+            ]);
+        })
+            ->name('games.show')
+            ->middleware([
+                RemoveResponsePayload::class . ':' . $key
+            ]);
+
+        // Refresh name lookup or test could fail...
+        Route::getRoutes()->refreshNameLookups();
+
+        // ------------------------------------------------------------------ //
+
+        $url = route('games.show', 42) . '?' . $key . '=1';
+        $response = $this
+            ->patchJson($url, [
+                'name' => 'Sine Gordon'
+            ])
+            ->assertNoContent();
+
+        Response::decode($response);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     *
+     * @throws JsonException
+     */
+    public function doesNotConvertWhenResponseIsNotSuccessful(): void
+    {
+        $key = 'nrp';
+        Route::patch('/games/{id}', function (Request $request) {
+            return response()->json([
+                'error' => 'some error'
+            ], Status::UNPROCESSABLE_ENTITY);
+        })
+            ->name('games.show')
+            ->middleware([
+                RemoveResponsePayload::class . ':' . $key
+            ]);
+
+        // Refresh name lookup or test could fail...
+        Route::getRoutes()->refreshNameLookups();
+
+        // ------------------------------------------------------------------ //
+
+        $url = route('games.show', 42) . '?' . $key . '=1';
+        $response = $this
+            ->patchJson($url, [
+                'name' => 'Sine Gordon'
+            ])
+            ->assertUnprocessable();
+
+        Response::decode($response);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     *
+     * @throws JsonException
+     */
+    public function keepsOriginalHeaders(): void
+    {
+        $key = 'nrp';
+        Route::patch('/games/{id}', function (Request $request) {
+            return response()->json([
+                'name' => $request->get('name', 'N/A')
+            ], Status::OK, [
+                'X-Custom' => 'Sweet'
+            ]);
+        })
+            ->name('games.show')
+            ->middleware([
+                RemoveResponsePayload::class . ':' . $key
+            ]);
+
+        // Refresh name lookup or test could fail...
+        Route::getRoutes()->refreshNameLookups();
+
+        // ------------------------------------------------------------------ //
+
+        $url = route('games.show', 42) . '?' . $key . '=1';
+        $response = $this
+            ->patchJson($url, [
+                'name' => 'Sine Gordon'
+            ])
+            ->assertNoContent();
+
+        Response::decode($response);
+
+        // ------------------------------------------------------------------ //
+
+        $headers = $response->headers;
+        $this->assertTrue($headers->has('x-custom'));
+        $this->assertSame('Sweet', $headers->get('x-custom'));
+    }
+}


### PR DESCRIPTION
Adds `RemoveResponsePayload` middleware, which is able to convert response to a "204 No Content" response, if a `no_payload` query parameter is requested and the response is successful.
The `no_payload` key can be configured to a different value
