### PR TITLE
Improve deploy docs script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Improved the `deploy-docs.sh` script.
+
 ## [7.1.0] - 2023-02-18
 
 ### Added 

--- a/deploy-docs.sh
+++ b/deploy-docs.sh
@@ -3,9 +3,18 @@
 # abort on errors
 set -e
 
-# TODO: Clear out built first, or risk of "error: src refspec main does not match any"... or similar issues..
+# A few properties
+repository="git@github.com:aedart/athenaeum.git"
+branch="main:gh-pages"
+build_directory=".build"
 
-# build
+# Clear the build directory, but keep the directory
+cd "$build_directory"
+find . -type f -delete
+find . -type d -delete
+cd ..
+
+# build the docs
 if command -v "yarn" > /dev/null;
 then
     yarn run docs:build-prod
@@ -14,11 +23,12 @@ else
 fi
 
 # navigate into the build output directory
-cd .build
+cd "$build_directory"
 
 # if you are deploying to a custom domain
 # echo 'www.example.com' > CNAME
 
+# Init repository and commit all files
 git init
 git add -A
 git commit -m 'deploy docs'
@@ -27,6 +37,6 @@ git commit -m 'deploy docs'
 # git push -f git@github.com:<USERNAME>/<USERNAME>.github.io.git main
 
 # if you are deploying to https://<USERNAME>.github.io/<REPO>
-git push -f git@github.com:aedart/athenaeum.git main:gh-pages
+git push -f $repository $branch
 
 cd -


### PR DESCRIPTION
Minor improvements for the `deploy-docs.sh` script. Ensures that the `.build` directory is cleared, before a new docs build is made.
