### PR TITLE
Add stream copy from method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Incorrect "is readable" check of source stream in `copy()` and `copyTo()`, in `FileStream`.
+* Incorrect description of `append()` method in documentation, regarding PSR-7 stream detaching.
 
 ## [7.3.0] - 2023-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Improved method description of `copy()` and `copyTo()` methods, in `FileStream`.
 * Renamed internal `performCopy()` to `copySourceToTarget()` in `Copying` concern in Stream package.
 
+### Fixed
+
+* Incorrect "is readable" check of source stream in `copy()` and `copyTo()`, in `FileStream`.
+
 ## [7.3.0] - 2023-02-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Improved method description of `copy()` and `copyTo()` methods, in `FileStream`.
+
 ## [7.3.0] - 2023-02-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Improved method description of `copy()` and `copyTo()` methods, in `FileStream`.
+* Renamed internal `performCopy()` to `copySourceToTarget()` in `Copying` concern in Stream package.
 
 ## [7.3.0] - 2023-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `buffer()` method in `Stream` (_not yet available in interface_).
 * `copyFrom()` method in `FileStream` (_not yet available in interface_).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Improved method description of `copy()` and `copyTo()` methods, in `FileStream`.
 * Renamed internal `performCopy()` to `copySourceToTarget()` in `Copying` concern in Stream package.
+* Refactored internal `outputSingleRange()` method in `DownloadStream`. Now uses stream `buffer()` method.
+* Improved method description of `copy()` and `copyTo()` methods, in `FileStream`.
 * Improved documentation regarding which read methods automatically rewinds the stream. 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* `copyFrom()` method in `FileStream` (_not yet available in interface_).
+
 ### Changed
 
 * Improved method description of `copy()` and `copyTo()` methods, in `FileStream`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Improved method description of `copy()` and `copyTo()` methods, in `FileStream`.
 * Renamed internal `performCopy()` to `copySourceToTarget()` in `Copying` concern in Stream package.
+* Improved documentation regarding which read methods automatically rewinds the stream. 
 
 ### Fixed
 

--- a/docs/archive/current/streams/usage/reading.md
+++ b/docs/archive/current/streams/usage/reading.md
@@ -84,8 +84,7 @@ Behind the scene, [PHP's `fgetc()`](https://www.php.net/manual/en/function.fgetc
 $resource = fopen('php://memory', 'r+b');
 fwrite($resource, 'abc');
 
-$stream = FileStream::make($resource)
-    ->positionToStart();
+$stream = FileStream::make($resource);
 
 // Read all characters...
 $buffer = '';
@@ -96,6 +95,10 @@ foreach ($characters as $character) {
 
 echo $buffer; // abc
 ```
+
+::: tip Note
+_This method automatically rewinds the stream to its beginning. See [`readCharacter()`](#single-character) as an alternative method._
+:::
 
 ## Read Lines
 
@@ -188,8 +191,7 @@ It returns an [`iterable`](https://www.php.net/manual/en/language.types.iterable
 $resource = fopen('php://memory', 'r+b');
 fwrite($resource, "a\nb\nc\n");
 
-$stream = FileStream::make($resource)
-    ->positionToStart();
+$stream = FileStream::make($resource);
 
 // Read all lines...
 $buffer = '';
@@ -200,6 +202,10 @@ foreach ($lines as $line) {
 
 echo $buffer; // abc
 ```
+
+::: tip Note
+_This method automatically rewinds the stream to its beginning. See [`readLine()`](#single-line) as an alternative method._
+:::
 
 ::: tip Automatic Trim
 Unlike the `readLine()` method, `readAllLines()` automatically trims all lines before returning.
@@ -232,8 +238,7 @@ In the following example, each line is returned when either of these conditions 
 $resource = fopen('php://memory', 'r+b');
 fwrite($resource, "aa||bb||cc");
 
-$stream = FileStream::make($resource)
-    ->positionToStart();
+$stream = FileStream::make($resource);
 
 // Read all lines using a length / delimiter
 $buffer = '';
@@ -244,6 +249,10 @@ foreach ($iterator as $line) {
 
 echo $buffer; // aabbcc
 ```
+
+::: tip Note
+_This method automatically rewinds the stream to its beginning. See [`readLineUntil()`](#single-line-until) as an alternative method._
+:::
 
 ## Scan Format
 
@@ -280,8 +289,7 @@ Use `readAllUsingFormat()` to scan entire stream's content according to specifie
 $resource = fopen('php://memory', 'r+b');
 fwrite($resource, "aa||\nbb||\ncc||\n");
 
-$stream = FileStream::make($resource)
-    ->positionToStart();
+$stream = FileStream::make($resource);
 
 // Scan according to format
 $buffer = '';
@@ -292,6 +300,10 @@ foreach ($all as $scanned) {
 
 echo $buffer; // aa||bb||cc||
 ```
+
+::: tip Note
+_This method automatically rewinds the stream to its beginning. See [`scan()`](#scan-format) as an alternative method._
+:::
 
 ## Read Chunks
 
@@ -315,6 +327,10 @@ foreach ($chunks as $chunk) {
 
 echo $buffer; // abc
 ```
+
+::: tip Note
+_This method automatically rewinds the stream to its beginning. See [`buffer()`](#buffer) as an alternative method._
+:::
 
 ## Read All using Callback
 
@@ -346,7 +362,7 @@ echo $buffer; // aabbcc
 ```
 
 ::: tip Note
-The position is automatically set to `0` (_the beginning of the stream_), when invoking the `readAllUsing()` method.
+_This method automatically rewinds the stream to its beginning. See [`buffer()`](#buffer) as an alternative method._
 :::
 
 ## Buffer

--- a/docs/archive/current/streams/usage/reading.md
+++ b/docs/archive/current/streams/usage/reading.md
@@ -348,3 +348,26 @@ echo $buffer; // aabbcc
 ::: tip Note
 The position is automatically set to `0` (_the beginning of the stream_), when invoking the `readAllUsing()` method.
 :::
+
+## Buffer
+
+_**Available since** `v7.4.x`_
+
+To read the stream in chunks, using a specific buffer size, use the `buffer()` method.
+It accepts the following arguments:
+
+* `int|null $length = null`: (_optional_) Maximum bytes to read from stream. By default, all bytes left are read.
+* `int $offset = 0`: (_optional_) The offset on where to start to reading from.
+* `int $bufferSize = BufferSizes::BUFFER_8KB`: (_optional_) Read buffer size of each chunk in bytes.
+
+```php
+$iterator = $stream->buffer(
+    length: 250,
+    offset: 22,
+    bufferSize: 50
+);
+
+foreach ($iterator as $chunk) {
+    echo $chunk;
+}
+```

--- a/docs/archive/current/streams/usage/reading.md
+++ b/docs/archive/current/streams/usage/reading.md
@@ -97,7 +97,7 @@ echo $buffer; // abc
 ```
 
 ::: tip Note
-_This method automatically rewinds the stream to its beginning. See [`readCharacter()`](#single-character) as an alternative method._
+_This method automatically rewinds the stream. See [`readCharacter()`](#single-character) as an alternative method._
 :::
 
 ## Read Lines
@@ -204,7 +204,7 @@ echo $buffer; // abc
 ```
 
 ::: tip Note
-_This method automatically rewinds the stream to its beginning. See [`readLine()`](#single-line) as an alternative method._
+_This method automatically rewinds the stream. See [`readLine()`](#single-line) as an alternative method._
 :::
 
 ::: tip Automatic Trim
@@ -251,7 +251,7 @@ echo $buffer; // aabbcc
 ```
 
 ::: tip Note
-_This method automatically rewinds the stream to its beginning. See [`readLineUntil()`](#single-line-until) as an alternative method._
+_This method automatically rewinds the stream. See [`readLineUntil()`](#single-line-until) as an alternative method._
 :::
 
 ## Scan Format
@@ -302,7 +302,7 @@ echo $buffer; // aa||bb||cc||
 ```
 
 ::: tip Note
-_This method automatically rewinds the stream to its beginning. See [`scan()`](#scan-format) as an alternative method._
+_This method automatically rewinds the stream. See [`scan()`](#scan-format) as an alternative method._
 :::
 
 ## Read Chunks
@@ -329,7 +329,7 @@ echo $buffer; // abc
 ```
 
 ::: tip Note
-_This method automatically rewinds the stream to its beginning. See [`buffer()`](#buffer) as an alternative method._
+_This method automatically rewinds the stream. See [`buffer()`](#buffer) as an alternative method._
 :::
 
 ## Read All using Callback
@@ -362,7 +362,7 @@ echo $buffer; // aabbcc
 ```
 
 ::: tip Note
-_This method automatically rewinds the stream to its beginning. See [`buffer()`](#buffer) as an alternative method._
+_This method automatically rewinds the stream. See [`buffer()`](#buffer) as an alternative method._
 :::
 
 ## Buffer

--- a/docs/archive/current/streams/usage/writing.md
+++ b/docs/archive/current/streams/usage/writing.md
@@ -203,6 +203,8 @@ echo (string) $copy; // b
 
 ### Copy From
 
+_**Available since** `v7.4.x`_
+
 Alternatively, you may also copy data from an existing resource or stream.
 
 ```php

--- a/packages/Contracts/src/Streams/FileStream.php
+++ b/packages/Contracts/src/Streams/FileStream.php
@@ -78,6 +78,8 @@ interface FileStream extends Stream
      *
      * Method is the equivalent of invoking {@see copyTo()} without a `$target`.
      *
+     * **Note**: _Neither this stream nor the copy stream are rewind after copy operation!_
+     *
      * @see copyTo()
      *
      * @param  int|null  $length  [optional] Maximum bytes to copy. By default, all bytes left are copied
@@ -93,6 +95,8 @@ interface FileStream extends Stream
      * Copy this stream into another stream
      *
      * @see https://www.php.net/manual/en/function.stream-copy-to-stream.php
+     *
+     * **Note**: _Neither this stream nor the target stream are rewind after copy operation!_
      *
      * @param  Stream|null  $target  [optional] Target stream to copy this stream's content into.
      *                               If `null` is given, then a new stream instance

--- a/packages/Contracts/src/Streams/FileStream.php
+++ b/packages/Contracts/src/Streams/FileStream.php
@@ -78,7 +78,7 @@ interface FileStream extends Stream
      *
      * Method is the equivalent of invoking {@see copyTo()} without a `$target`.
      *
-     * **Note**: _Neither this stream nor the copy stream are rewind after copy operation!_
+     * **Note**: _Neither this stream nor the copy stream are rewound after copy operation!_
      *
      * @see copyTo()
      *
@@ -96,7 +96,7 @@ interface FileStream extends Stream
      *
      * @see https://www.php.net/manual/en/function.stream-copy-to-stream.php
      *
-     * **Note**: _Neither this stream nor the target stream are rewind after copy operation!_
+     * **Note**: _Neither this stream nor the target stream are rewound after copy operation!_
      *
      * @param  Stream|null  $target  [optional] Target stream to copy this stream's content into.
      *                               If `null` is given, then a new stream instance

--- a/packages/Streams/src/Concerns/Buffering.php
+++ b/packages/Streams/src/Concerns/Buffering.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Aedart\Streams\Concerns;
+
+use Aedart\Contracts\Streams\BufferSizes;
+use Aedart\Streams\Exceptions\StreamException;
+use Aedart\Streams\Exceptions\StreamNotReadable;
+use Aedart\Streams\Exceptions\StreamNotSeekable;
+use Psr\Http\Message\StreamInterface as PsrStreamInterface;
+
+/**
+ * Concerns Buffering
+ *
+ * @author Alin Eugen Deac <aedart@gmail.com>
+ * @package Aedart\Streams\Concerns
+ */
+trait Buffering
+{
+    /**
+     * Read stream in chunks of specified buffer size
+     *
+     * @param  PsrStreamInterface  $source The stream to read from.
+     * @param  int|null  $length  [optional] Maximum bytes to read from stream. By default, all bytes left are read.
+     * @param  int  $offset  [optional] The offset on where to start to reading from.
+     * @param  int  $bufferSize  [optional] Read buffer size of each chunk in bytes.
+     *
+     * @return iterable<string>
+     */
+    protected function bufferStream(
+        PsrStreamInterface $source,
+        int|null $length = null,
+        int $offset = 0,
+        int $bufferSize = BufferSizes::BUFFER_8KB
+    ): iterable {
+        // Abort if not readable or seekable
+        if (!$source->isReadable()) {
+            throw new StreamNotReadable('Source stream is not readable.');
+        }
+        if (!$source->isSeekable()) {
+            throw new StreamNotSeekable('Source stream is not seekable.');
+        }
+
+        // Abort in case that source's size cannot be determined.
+        $size = (int) $source->getSize();
+        if ($size === 0) {
+            throw new StreamException('Unable to read size of source stream.');
+        }
+
+        // Seek position in source stream
+        $source->seek($offset);
+
+        // Resolve the read length. Whenever it is less than the buffer size,
+        // just read and write the data.
+        $length = $length ?? $size - $source->tell();
+        if ($length <= $bufferSize && !$source->eof()) {
+            yield $source->read($length);
+        }
+
+        // Read the remaining of the stream in chunks of the specified buffer size.
+        $end = $offset + $length - 1;
+        $readLength = $bufferSize;
+
+        while (!$source->eof() && ($position = $source->tell()) <= $end) {
+            // Prevent out-of-bounds issues
+            if ($position + $bufferSize > $end) {
+                $readLength = $end - $position + 1;
+            }
+
+            // Read chunk...
+            yield $source->read($readLength);
+        }
+    }
+}

--- a/packages/Streams/src/Concerns/Copying.php
+++ b/packages/Streams/src/Concerns/Copying.php
@@ -15,7 +15,7 @@ use Aedart\Streams\Exceptions\StreamException;
 trait Copying
 {
     /**
-     * Perform copy of this stream into given target
+     * Perform copy of source stream into given target
      *
      * @param  StreamInterface  $source The source to copy from
      * @param  StreamInterface  $target The target to copy to

--- a/packages/Streams/src/Concerns/Copying.php
+++ b/packages/Streams/src/Concerns/Copying.php
@@ -67,8 +67,7 @@ trait Copying
         int|null $length = null,
         int $offset = 0,
         int $bufferSize = BufferSizes::BUFFER_8KB
-    ): int
-    {
+    ): int {
         // Abort if source is not readable or seekable
         if (!$source->isReadable() || !$source->isSeekable()) {
             throw new CannotCopyToTargetStream('Source stream is either not readable or seekable.');

--- a/packages/Streams/src/Concerns/Copying.php
+++ b/packages/Streams/src/Concerns/Copying.php
@@ -15,18 +15,18 @@ use Aedart\Streams\Exceptions\StreamException;
 trait Copying
 {
     /**
-     * Perform copy of source stream into given target
+     * Perform copy of source stream into given target stream
      *
      * @param  StreamInterface  $source The source to copy from
      * @param  StreamInterface  $target The target to copy to
-     * @param  int|null  $length  [optional]
-     * @param  int  $offset  [optional]
+     * @param  int|null  $length  [optional] Maximum bytes to copy from source stream. By default, all bytes left are copied
+     * @param  int  $offset  [optional] The offset on source stream where to start to copy data from
      *
      * @return int Bytes copied
      *
      * @throws StreamException
      */
-    protected function performCopy(StreamInterface $source, StreamInterface $target, int|null $length = null, int $offset = 0): int
+    protected function copySourceToTarget(StreamInterface $source, StreamInterface $target, int|null $length = null, int $offset = 0): int
     {
         // Abort if source is detached or not readable
         if ($source->isDetached() || !$target->isReadable()) {

--- a/packages/Streams/src/Concerns/Copying.php
+++ b/packages/Streams/src/Concerns/Copying.php
@@ -38,7 +38,7 @@ trait Copying
             throw new CannotCopyToTargetStream('Target stream is either detached or not writable.');
         }
 
-        return $this->copyResourceTo(
+        return $this->copyRawResource(
             $source->resource(),
             $target->resource(),
             $length,
@@ -60,7 +60,7 @@ trait Copying
      *
      * @throws StreamException
      */
-    protected function copyResourceTo($source, $target, int|null $length = null, int $offset = 0): int
+    protected function copyRawResource($source, $target, int|null $length = null, int $offset = 0): int
     {
         $bytesCopied = stream_copy_to_stream(
             from: $source,

--- a/packages/Streams/src/Concerns/Copying.php
+++ b/packages/Streams/src/Concerns/Copying.php
@@ -70,7 +70,7 @@ trait Copying
         );
 
         if ($bytesCopied === false) {
-            throw new StreamException('Copy operation failed. Streams might be blocked or otherwise invalid, or "length" and "offset" are invalid');
+            throw new StreamException('Copy operation failed. Streams might be blocked, incorrect length, offset, or otherwise invalid');
         }
 
         return $bytesCopied;

--- a/packages/Streams/src/Concerns/Copying.php
+++ b/packages/Streams/src/Concerns/Copying.php
@@ -29,7 +29,7 @@ trait Copying
     protected function copySourceToTarget(StreamInterface $source, StreamInterface $target, int|null $length = null, int $offset = 0): int
     {
         // Abort if source is detached or not readable
-        if ($source->isDetached() || !$target->isReadable()) {
+        if ($source->isDetached() || !$source->isReadable()) {
             throw new CannotCopyToTargetStream('Source stream is either detached or not readable.');
         }
 

--- a/packages/Streams/src/Concerns/Copying.php
+++ b/packages/Streams/src/Concerns/Copying.php
@@ -38,11 +38,35 @@ trait Copying
             throw new CannotCopyToTargetStream('Target stream is either detached or not writable.');
         }
 
-        $bytesCopied = stream_copy_to_stream(
+        return $this->copyResourceTo(
             $source->resource(),
             $target->resource(),
             $length,
             $offset
+        );
+    }
+
+    /**
+     * Copy from a source resource to a target resource
+     *
+     * @see https://www.php.net/manual/en/function.stream-copy-to-stream
+     *
+     * @param  resource $source The source resource to copy from
+     * @param  resource $target The target resource to copy to
+     * @param  int|null  $length  [optional] Maximum bytes to copy from source stream. By default, all bytes left are copied
+     * @param  int  $offset  [optional] The offset on source stream where to start to copy data from
+     *
+     * @return int Bytes copied
+     *
+     * @throws StreamException
+     */
+    protected function copyResourceTo($source, $target, int|null $length = null, int $offset = 0): int
+    {
+        $bytesCopied = stream_copy_to_stream(
+            from: $source,
+            to: $target,
+            length: $length,
+            offset: $offset
         );
 
         if ($bytesCopied === false) {

--- a/packages/Streams/src/FileStream.php
+++ b/packages/Streams/src/FileStream.php
@@ -12,6 +12,7 @@ use Aedart\MimeTypes\Concerns\MimeTypeDetection;
 use Aedart\MimeTypes\Exceptions\MimeTypeDetectionException;
 use Aedart\Streams\Exceptions\CannotOpenStream;
 use Aedart\Streams\Exceptions\StreamException;
+use Psr\Http\Message\StreamInterface as PsrStreamInterface;
 use Throwable;
 
 /**
@@ -90,6 +91,33 @@ class FileStream extends Stream implements
         $this->performCopy($this, $target, $length, $offset);
 
         return $target;
+    }
+
+    /**
+     * Copy data from source stream into this stream
+     *
+     * @param  resource|PsrStreamInterface|StreamInterface $source  The source stream to copy from.
+     * @param  int|null  $length  [optional] Maximum bytes to copy from source stream. By default, all bytes left are copied
+     * @param  int  $offset  [optional] The offset on source stream where to start to copy data from
+     *
+     * @return static This stream with data appended from source stream
+     */
+    public function copyFrom($source, int|null $length = null, int $offset = 0): static
+    {
+        if (is_resource($source)) {
+            // Wrap ... copy, restore position and detach
+        }
+
+        if ($source instanceof StreamInterface) {
+            // Copy, restore position
+        }
+
+        if ($source instanceof PsrStreamInterface) {
+            // Uhm... copy, restore position... DO NOT DETACH.
+            // NOTE: We cannot obtain underlying resource here
+        }
+
+        // TODO: Throw exception if source type is unsupported...
     }
 
     /**

--- a/packages/Streams/src/FileStream.php
+++ b/packages/Streams/src/FileStream.php
@@ -3,6 +3,7 @@
 namespace Aedart\Streams;
 
 use Aedart\Contracts\MimeTypes\Detectable;
+use Aedart\Contracts\Streams\BufferSizes;
 use Aedart\Contracts\Streams\FileStream as FileStreamInterface;
 use Aedart\Contracts\Streams\Hashing\Hashable;
 use Aedart\Contracts\Streams\Locks\Lockable;
@@ -105,12 +106,19 @@ class FileStream extends Stream implements
      * @param  resource|PsrStreamInterface|StreamInterface  $source  The source stream to copy from.
      * @param  int|null  $length  [optional] Maximum bytes to copy from source stream. By default, all bytes left are copied
      * @param  int  $offset  [optional] The offset on source stream where to start to copy data from
+     * @param  int  $bufferSize  [optional] Read/Write size of each chunk in bytes.
+     *                           Applicable ONLY if `$source` is instance of {@see PsrStreamInterface}.
      *
      * @return static This stream with data appended from source stream
      *
      * @throws \Aedart\Contracts\Streams\Exceptions\StreamException
      */
-    public function copyFrom($source, int|null $length = null, int $offset = 0): static
+    public function copyFrom(
+        $source,
+        int|null $length = null,
+        int $offset = 0,
+        int $bufferSize = BufferSizes::BUFFER_8KB
+    ): static
     {
         // Obtain underlying resource, when a stream instance is provided.
         if ($source instanceof StreamInterface) {
@@ -141,7 +149,8 @@ class FileStream extends Stream implements
                 source: $source,
                 target: $this,
                 length: $length,
-                offset: $offset
+                offset: $offset,
+                bufferSize: $bufferSize
             );
 
             return $this;

--- a/packages/Streams/src/FileStream.php
+++ b/packages/Streams/src/FileStream.php
@@ -118,8 +118,7 @@ class FileStream extends Stream implements
         int|null $length = null,
         int $offset = 0,
         int $bufferSize = BufferSizes::BUFFER_8KB
-    ): static
-    {
+    ): static {
         // Obtain underlying resource, when a stream instance is provided.
         if ($source instanceof StreamInterface) {
             if ($source->isDetached() || !$source->isReadable()) {

--- a/packages/Streams/src/FileStream.php
+++ b/packages/Streams/src/FileStream.php
@@ -96,6 +96,8 @@ class FileStream extends Stream implements
     /**
      * Copy data from source stream into this stream
      *
+     * **Note**: _Neither this stream nor the source stream are rewind after copy operation!_
+     *
      * @param  resource|PsrStreamInterface|StreamInterface $source  The source stream to copy from.
      * @param  int|null  $length  [optional] Maximum bytes to copy from source stream. By default, all bytes left are copied
      * @param  int  $offset  [optional] The offset on source stream where to start to copy data from

--- a/packages/Streams/src/FileStream.php
+++ b/packages/Streams/src/FileStream.php
@@ -88,7 +88,7 @@ class FileStream extends Stream implements
     {
         $target = $target ?? static::openTemporary();
 
-        $this->performCopy($this, $target, $length, $offset);
+        $this->copySourceToTarget($this, $target, $length, $offset);
 
         return $target;
     }
@@ -131,7 +131,7 @@ class FileStream extends Stream implements
     ): static {
         $this
             ->positionToEnd()
-            ->performCopy(
+            ->copySourceToTarget(
                 $this->wrap($data, $maximumMemory),
                 $this,
                 $length,

--- a/packages/Streams/src/Stream.php
+++ b/packages/Streams/src/Stream.php
@@ -26,6 +26,8 @@ use Traversable;
  */
 class Stream implements StreamInterface
 {
+    use Concerns\Buffering;
+
     /**
      * Readable modes regex
      *
@@ -501,6 +503,23 @@ class Stream implements StreamInterface
         while (!feof($resource)) {
             yield $callback($resource);
         }
+    }
+
+    /**
+     * Read from this stream in chunks of specified buffer size
+     *
+     * @param  int|null  $length  [optional] Maximum bytes to read from stream. By default, all bytes left are read.
+     * @param  int  $offset  [optional] The offset on where to start to reading from.
+     * @param  int  $bufferSize  [optional] Read buffer size of each chunk in bytes.
+     *
+     * @return iterable<string>
+     */
+    public function buffer(
+        int|null $length = null,
+        int $offset = 0,
+        int $bufferSize = BufferSizes::BUFFER_8KB
+    ): iterable {
+        return $this->bufferStream($this, $length, $offset, $bufferSize);
     }
 
     /**

--- a/tests/Integration/Streams/File/B0_CopyTest.php
+++ b/tests/Integration/Streams/File/B0_CopyTest.php
@@ -2,6 +2,7 @@
 
 namespace Aedart\Tests\Integration\Streams\File;
 
+use Aedart\Contracts\Streams\Exceptions\StreamException;
 use Aedart\Streams\FileStream;
 use Aedart\Tests\TestCases\Streams\StreamTestCase;
 
@@ -20,9 +21,10 @@ class B0_CopyTest extends StreamTestCase
      * @test
      *
      * @return void
-     * @throws \Aedart\Contracts\Streams\Exceptions\StreamException
+     * 
+     * @throws StreamException
      */
-    public function canCopyStream()
+    public function canCopyStream(): void
     {
         $data = $this->getFaker()->realText(25);
         $stream = FileStream::openMemory()
@@ -39,9 +41,10 @@ class B0_CopyTest extends StreamTestCase
      * @test
      *
      * @return void
-     * @throws \Aedart\Contracts\Streams\Exceptions\StreamException
+     *
+     * @throws StreamException
      */
-    public function canCopyToTargetStream()
+    public function canCopyToTargetStream(): void
     {
         $data = $this->getFaker()->realText(25);
 


### PR DESCRIPTION
Adds a new `copyFrom()` method in `FileStream`. It is able to safely copy the contents of its source resource or stream into the current stream. It also deals with PSR-7 streams, without detaching its underlying resource.

In addition, a new `buffer()` method has been added in `Stream`, which can read a length of the stream, from an offset and return chunks of data.

## Details

See `CHANGELOG.md` for additional details.

## References

* #156 
