### PR TITLE
Add base rule replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `BaseValidationRule` abstraction in Validation package.
 * `buffer()` method in `Stream` (_not yet available in interface_).
 * `copyFrom()` method in `FileStream` (_not yet available in interface_).
 
@@ -23,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Incorrect "is readable" check of source stream in `copy()` and `copyTo()`, in `FileStream`.
 * Incorrect description of `append()` method in documentation, regarding PSR-7 stream detaching.
+
+### Deprecated
+
+* All concerns in the `\Aedart\Validation\Rules\Concerns\*` namespace. These will be removed in the next major version. 
+* `\Aedart\Contracts\Validation\FailedState`. Will be removed in the next major version.
+* `\Aedart\Validation\Rules\BaseRule`. Will be removed in the next major version. Use `\Aedart\Validation\Rules\BaseValidationRule` instead. 
 
 ## [7.3.0] - 2023-02-23
 

--- a/packages/Contracts/src/Validation/FailedState.php
+++ b/packages/Contracts/src/Validation/FailedState.php
@@ -5,6 +5,8 @@ namespace Aedart\Contracts\Validation;
 use UnitEnum;
 
 /**
+ * @deprecated Since 7.4 - Will be removed in next major version
+ *
  * Validation Failed State
  *
  * @author Alin Eugen Deac <aedart@gmail.com>

--- a/packages/Validation/src/Rules/BaseRule.php
+++ b/packages/Validation/src/Rules/BaseRule.php
@@ -6,6 +6,8 @@ use Aedart\Contracts\Support\Helpers\Translation\TranslatorAware;
 use Illuminate\Contracts\Validation\Rule;
 
 /**
+ * @deprecated Since 7.4 - Use {@see BaseValidationRule} instead
+ *
  * Base Validation Rule
  *
  * Abstraction that offers common utility methods for

--- a/packages/Validation/src/Rules/BaseValidationRule.php
+++ b/packages/Validation/src/Rules/BaseValidationRule.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Aedart\Validation\Rules;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Base Validation Rule
+ *
+ * @see \Illuminate\Contracts\Validation\ValidationRule
+ *
+ * @author Alin Eugen Deac <aedart@gmail.com>
+ * @package Aedart\Validation\Rules
+ */
+abstract class BaseValidationRule implements ValidationRule
+{
+}

--- a/packages/Validation/src/Rules/Concerns/AthenaeumRule.php
+++ b/packages/Validation/src/Rules/Concerns/AthenaeumRule.php
@@ -3,6 +3,8 @@
 namespace Aedart\Validation\Rules\Concerns;
 
 /**
+ * @deprecated Since 7.4 - Will be removed in next major version
+ *
  * Concerns Athenaeum Validation Rule
  *
  * @author Alin Eugen Deac <aedart@gmail.com>

--- a/packages/Validation/src/Rules/Concerns/Attribute.php
+++ b/packages/Validation/src/Rules/Concerns/Attribute.php
@@ -3,6 +3,8 @@
 namespace Aedart\Validation\Rules\Concerns;
 
 /**
+ * @deprecated Since 7.4 - Will be removed in next major version
+ *
  * Concerns Attribute
  *
  * @author Alin Eugen Deac <aedart@gmail.com>

--- a/packages/Validation/src/Rules/Concerns/Translations.php
+++ b/packages/Validation/src/Rules/Concerns/Translations.php
@@ -6,6 +6,8 @@ use Aedart\Support\Helpers\Translation\TranslatorTrait;
 use Aedart\Utils\Str;
 
 /**
+ * @deprecated Since 7.4 - Will be removed in next major version
+ *
  * Concerns Translations
  *
  * @author Alin Eugen Deac <aedart@gmail.com>

--- a/packages/Validation/src/Rules/Concerns/ValidationFailure.php
+++ b/packages/Validation/src/Rules/Concerns/ValidationFailure.php
@@ -5,6 +5,8 @@ namespace Aedart\Validation\Rules\Concerns;
 use Aedart\Contracts\Validation\FailedState;
 
 /**
+ * @deprecated Since 7.4 - Will be removed in next major version
+ *
  * Concerns Validation Failure
  *
  * @author Alin Eugen Deac <aedart@gmail.com>


### PR DESCRIPTION
Deprecation of various validation rule helpers, because of Laravel's deprecated `Rule` interface.

## Details

See `CHANGELOG.md`

## References

#158 
