### PR TITLE
Fix target identifier rules never applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Target identifier rules not applied in `ProcessMultipleResourcesRequest`. Rules were wrapped in a closure which never got invoked.
+
 ## [7.11.0] - 2023-04-15
 
 ### Changed

--- a/packages/Http/Api/src/Requests/Resources/ProcessMultipleResourcesRequest.php
+++ b/packages/Http/Api/src/Requests/Resources/ProcessMultipleResourcesRequest.php
@@ -63,9 +63,7 @@ abstract class ProcessMultipleResourcesRequest extends ValidatedApiRequest imple
                 "max:{$this->max}"
             ],
 
-            "{$key}.*" => function () {
-                return $this->targetIdentifierRules();
-            },
+            "{$key}.*" => $this->targetIdentifierRules(),
         ]);
     }
 


### PR DESCRIPTION
PR fixes issue in `ProcessMultipleResourcesRequest`'s applied validation rules. Basically the validation rules were wrapped in a closure, which was never invoked. This resulted in identifiers not being validated at all and could end up being applied / attempted used in the subsequent query.
