### PR TITLE
Fix undefined array key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Undefined array key when Http Status Code does not have a default status text, in `ApiErrorResponse::makeFor()`.
+
 ## [7.11.1] - 2023-04-18
 
 ### Fixed

--- a/packages/Http/Api/src/Responses/ApiErrorResponse.php
+++ b/packages/Http/Api/src/Responses/ApiErrorResponse.php
@@ -62,7 +62,7 @@ class ApiErrorResponse extends JsonResponse
         }
 
         // Resolve status text, based on status code
-        $message = Response::$statusTexts[$status];
+        $message = Response::$statusTexts[$status] ?? $e->getMessage();
 
         // Create new Api error response
         $response = static::make(


### PR DESCRIPTION
This fixes situation where provided Http Status code does not have a default status text, in `\Aedart\Http\Api\Responses\ApiErrorResponse::makeFor()`.

E.g. Laravel's `419 Page Expired` is not a default Http Status Code and does therefore not have an official status text.

> "_419 Page Expired_
> _Used by the Laravel Framework when a CSRF Token is missing or expired._" (source [wiki](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes))
