### PR TITLE
Fix after validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* "_Class based after validation rules_" feature (_introduced in Laravel `v10.8.0`_) breaks abstract `ApiValidatedRequest`. [#167](https://github.com/aedart/athenaeum/pull/167).
 * Undefined array key when Http Status Code does not have a default status text, in `ApiErrorResponse::makeFor()`. [#166](https://github.com/aedart/athenaeum/pull/166).
+
+### Deprecated
+
+* `after()` method in `ApiValidatedRequest`. This method will be removed in the next major version. Replaced by the new `afterValidation()` method.  [#168](https://github.com/aedart/athenaeum/pull/168).
 
 ## [7.11.1] - 2023-04-18
 

--- a/packages/Http/Api/src/Requests/ValidatedApiRequest.php
+++ b/packages/Http/Api/src/Requests/ValidatedApiRequest.php
@@ -2,6 +2,7 @@
 
 namespace Aedart\Http\Api\Requests;
 
+use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\ValidationException;
@@ -37,6 +38,41 @@ abstract class ValidatedApiRequest extends FormRequest
         if (method_exists($this, 'validateRouteParameters')) {
             $this->validateRouteParameters();
         }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getValidatorInstance()
+    {
+        if ($this->validator) {
+            return $this->validator;
+        }
+
+        $factory = $this->container->make(ValidationFactory::class);
+
+        if (method_exists($this, 'validator')) {
+            $validator = $this->container->call([$this, 'validator'], compact('factory'));
+        } else {
+            $validator = $this->createDefaultValidator($factory);
+        }
+
+        if (method_exists($this, 'withValidator')) {
+            $this->withValidator($validator);
+        }
+
+        // TODO: This disables the "after validation rules" feature introduced by Laravel in v10.8.0
+        // TODO @see https://github.com/aedart/athenaeum/issues/167
+//        if (method_exists($this, 'after')) {
+//            $validator->after($this->container->call(
+//                $this->after(...),
+//                ['validator' => $validator]
+//            ));
+//        }
+
+        $this->setValidator($validator);
+
+        return $this->validator;
     }
 
     /**

--- a/packages/Http/Api/src/Requests/ValidatedApiRequest.php
+++ b/packages/Http/Api/src/Requests/ValidatedApiRequest.php
@@ -76,6 +76,8 @@ abstract class ValidatedApiRequest extends FormRequest
     }
 
     /**
+     * @deprecated Since 7.12.0 - Use `afterValidation` instead. Will be removed in next major version.
+     *
      * Perform post request data validation, e.g. business logic validation
      *
      * @param  Validator  $validator
@@ -88,6 +90,22 @@ abstract class ValidatedApiRequest extends FormRequest
     public function after(Validator $validator): void
     {
         // Business logic validation, e.g. complex record existence check, cross field validation... etc
+    }
+
+    /**
+     * Perform post request data validation, e.g. business logic validation
+     *
+     * @param Validator $validator
+     *
+     * @return void
+     *
+     * @throws ValidationException
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public function afterValidation(Validator $validator): void
+    {
+        // Overwrite this method to add custom business logic validation.
+        // E.g. complex record existence checks, more advanced cross field validation... etc.
     }
 
     /**
@@ -123,7 +141,8 @@ abstract class ValidatedApiRequest extends FormRequest
     {
         $validator
             ->after([$this, 'prepareForAfterValidation'])
-            ->after([$this, 'after']);
+            ->after([$this, 'after']) // TODO: Deprecated
+            ->after([$this, 'afterValidation']);
     }
 
 //    /**


### PR DESCRIPTION
PR fixes the following defect:

* #167 

## Details

Sadly, Laravel's feature has now manually been disabled / overwritten, to ensure that the `ApiValidatedRequest` continues to work as intended. Also, a new `afterValidation()` method has been introduced, which replaces the now deprecated `after()` method.
Other Api request abstractions that rely on `after()` have not yet been updated, but that wait until the next major version,...

## References

_See also #168._
