### PR TITLE
Add datetime format validation rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Custom `DateFormat` validation rule.
 
+### Changed
+
+* `DateFilter` and `DateTimeFilter` are now be able to accept RFC 3339 Extended Zulu formatted input and deal with UTC, even when timezone is submitted as `'+00:00'`, `'-00:00'` or `'Z'`.
+
 ## [7.11.3] - 2023-04-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Custom `DateFormat` validation rule.
+
 ## [7.11.3] - 2023-04-28
 
 ### Fixed

--- a/docs/.vuepress/archive/Version7x.ts
+++ b/docs/.vuepress/archive/Version7x.ts
@@ -669,6 +669,7 @@ export default PagesCollection.make('v7.x', '/v7x', [
                 collapsible: true,
                 children: [
                     'validation/rules/alpha-dash-dot',
+                    'validation/rules/date-format',
                     'validation/rules/semantic-version',
                 ]
             },

--- a/docs/archive/current/validation/rules/date-format.md
+++ b/docs/archive/current/validation/rules/date-format.md
@@ -1,0 +1,25 @@
+---
+description: Date Format validation rule
+---
+
+# Date Format
+
+_**Available since** `v7.12.x`_
+
+Adaptation of Laravel's [`date_format`](https://laravel.com/docs/10.x/validation#rule-date-format) rule.
+The difference is that, this rule handles an edge case that concerns UTC timezone offset.
+
+If allowed date format contains the [`p` token (_timezone offset_)](https://www.php.net/manual/en/datetime.format.php),
+and the date in question contains +00:00 or "Z" (_UTC_) as timezone offset, then this rule will use a slightly different comparison that ensures desired outcome. 
+
+For instance, if you expect a date format like `'Y-m-d\TH:i:sp'`, then the following equivalent dates will pass validation.
+* `2023-01-01T11:25:00+00:00`
+* `2023-01-01T11:25:00Z`
+
+```php
+use Aedart\Validation\Rules\DateFormat;
+
+$data = $request->validate([
+    'performed_at' => [ new DateFormat('Y-m-d\TH:i:sp') ],
+]);
+```

--- a/packages/Filters/src/Query/Filters/Fields/DateFilter.php
+++ b/packages/Filters/src/Query/Filters/Fields/DateFilter.php
@@ -3,6 +3,7 @@
 namespace Aedart\Filters\Query\Filters\Fields;
 
 use Aedart\Utils\Arr;
+use Aedart\Validation\Rules\DateFormat;
 use Illuminate\Contracts\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Contracts\Database\Query\Builder;
 use InvalidArgumentException;
@@ -109,7 +110,7 @@ class DateFilter extends BaseFieldFilter
         // array-undot call. This is done in case of evt. table name prefixes, then we must
         // ensure that the "data" is associative, or the applied validation rule might fail.
         $validator = $this->getValidatorFactory()->make(Arr::undot([ $field => $value ]), [
-            $field => 'required|date_format:' . implode(',', $this->allowedDateFormats())
+            $field => [ 'required', new DateFormat(...$this->allowedDateFormats()) ]
         ]);
 
         if ($validator->fails()) {

--- a/packages/Validation/src/Rules/DateFormat.php
+++ b/packages/Validation/src/Rules/DateFormat.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Aedart\Validation\Rules;
+
+use Carbon\Exceptions\InvalidFormatException;
+use Closure;
+use Illuminate\Support\Carbon;
+use ValueError;
+
+/**
+ * Date Format Validation Rule
+ *
+ * Ensures given attribute is a date string according to an allowed format.
+ *
+ * @author Alin Eugen Deac <aedart@gmail.com>
+ * @package Aedart\Validation\Rules
+ */
+class DateFormat extends BaseValidationRule
+{
+    /**
+     * Allowed formats
+     *
+     * @var string[]
+     */
+    protected array $formats;
+
+    /**
+     * Create new instance of validation rule
+     *
+     * @param string ...$formats
+     */
+    public function __construct(...$formats)
+    {
+        $this->formats = $formats;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (!$this->isValid($value)) {
+            $fail('validation.date_format')->translate([
+                'attribute' => $attribute,
+                'format' => $this->formats[0]
+            ]);
+        }
+    }
+
+    /**
+     * Determine if given date is valid (can be created acc. to allowed format)
+     *
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public function isValid(mixed $value): bool
+    {
+        if (empty($value) || (!is_string($value) && !is_numeric($value))) {
+            return false;
+        }
+
+        foreach ($this->formats as $format) {
+            try {
+                $date = Carbon::createFromFormat('!' . $format, $value);
+
+                // Skip to next format, if unable to create by format
+                if ($date === false) {
+                    continue;
+                }
+
+                // Pass, if exported format matches the string date (just like Laravel's
+                // 'date_format' validation rule )
+                if ($date->format($format) == $value) {
+                    return true;
+                }
+
+                // Edge-case: if the format contains 'p' token (timezone offset), e.g. RCF 3339 Extended Zulu,
+                // then the "format()" output comparison might fail if +00:00 timezone offset is submitted.
+                // The output of the format converts +00:00 to 'Z', which then fails format output comparison.
+                if (str_contains($format, 'p')
+                    && (str_ends_with($value, '+00:00') || str_ends_with($value, '-00:00'))
+                    && $date->eq($value)
+                ) {
+                    return true;
+                }
+            } catch (ValueError|InvalidFormatException $e) {
+                // Ignore value error / format exceptions. This is important when there are multiple
+                // allowed formats...
+                continue;
+            }
+        }
+
+        return false;
+    }
+}

--- a/packages/Validation/src/Rules/DateFormat.php
+++ b/packages/Validation/src/Rules/DateFormat.php
@@ -78,7 +78,8 @@ class DateFormat extends BaseValidationRule
                 // Edge-case: if the format contains 'p' token (timezone offset), e.g. RCF 3339 Extended Zulu,
                 // then the "format()" output comparison might fail if +00:00 timezone offset is submitted.
                 // The output of the format converts +00:00 to 'Z', which then fails format output comparison.
-                if (str_contains($format, 'p')
+                if (
+                    (str_contains($format, 'p') && !str_contains($format, '\\p'))           // Only when unescaped 'p' token is present
                     && (str_ends_with($value, '+00:00') || str_ends_with($value, '-00:00'))
                     && $date->eq($value)
                 ) {

--- a/tests/Integration/Validation/Rules/DateFormatRuleTest.php
+++ b/tests/Integration/Validation/Rules/DateFormatRuleTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Aedart\Tests\Integration\Validation\Rules;
+
+use Aedart\Contracts\Utils\Dates\DateTimeFormats;
+use Aedart\Tests\TestCases\Validation\ValidationTestCase;
+use Aedart\Validation\Rules\DateFormat;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * DateFormatRuleTest
+ *
+ * @group validation
+ * @group rules
+ * @group date-format
+ *
+ * @author Alin Eugen Deac <aedart@gmail.com>
+ * @package Aedart\Tests\Integration\Validation\Rules
+ */
+class DateFormatRuleTest extends ValidationTestCase
+{
+    /*****************************************************************
+     * Data Providers
+     ****************************************************************/
+
+    /**
+     * Provides input that should pass validation
+     *
+     * @return string[][]
+     */
+    public static function validInput(): array
+    {
+        return [
+            'single format' => [ '2023', [ 'Y' ] ],
+            'multiple formats' => [ '2023-04-22', [ 'Y-m', 'Y-m-d' ] ],
+            'RFC3339 EXTENDED ZULU (+00:00)' => [ '2023-03-23T07:36:14.000+00:00', [ DateTimeFormats::RFC3339_EXTENDED_ZULU ] ],
+            'RFC3339 EXTENDED ZULU (Z)' => [ '2023-03-23T07:36:14.000Z', [ DateTimeFormats::RFC3339_EXTENDED_ZULU ] ],
+            'RFC3339 EXTENDED ZULU (+02:00)' => [ '2023-03-23T07:36:14.000+02:00', [ DateTimeFormats::RFC3339_EXTENDED_ZULU ] ],
+            'RFC3339 EXTENDED ZULU (-01:00)' => [ '2023-03-23T07:36:14.000-01:00', [ DateTimeFormats::RFC3339_EXTENDED_ZULU ] ],
+        ];
+    }
+
+    /**
+     * Provides input that should not pass validation
+     *
+     * @return string[][]
+     */
+    public static function invalidInput(): array
+    {
+        return [
+            'not a string' => [ false, [ 'Y-m-d' ] ],
+            'not numeric string' => [ 'abc', [ 'Y-m-d' ] ],
+            'invalid date format' => [ '2023-27-01', [ 'Y-m-d' ] ],
+        ];
+    }
+
+    /*****************************************************************
+     * Helpers
+     ****************************************************************/
+
+
+    /**
+     * Returns new validation rule instance
+     *
+     * @param string[] $formats
+     *
+     * @return ValidationRule
+     */
+    public function makeRule(array $formats): ValidationRule
+    {
+        return new DateFormat(...$formats);
+    }
+
+    /*****************************************************************
+     * Actual Tests
+     ****************************************************************/
+
+    /**
+     * @test
+     * @dataProvider validInput
+     *
+     * @param mixed $input
+     * @param string[] $formats
+     *
+     * @return void
+     *
+     * @throws ValidationException
+     */
+    public function passesOnValidInput(mixed $input, array $formats): void
+    {
+        $this->shouldPass($input, $this->makeRule($formats));
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidInput
+     *
+     * @param mixed $input
+     * @param string[] $formats
+     *
+     * @return void
+     *
+     * @throws ValidationException
+     */
+    public function failsOnInvalidInput(mixed $input, array $formats): void
+    {
+        $this->shouldNotPass($input, $this->makeRule($formats));
+    }
+}

--- a/tests/TestCases/Validation/ValidationTestCase.php
+++ b/tests/TestCases/Validation/ValidationTestCase.php
@@ -7,6 +7,7 @@ use Aedart\Testing\Helpers\ConsoleDebugger;
 use Aedart\Testing\TestCases\LaravelTestCase;
 use Aedart\Validation\Providers\ValidationServiceProvider;
 use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Validation\ValidationException;
 
@@ -57,11 +58,11 @@ abstract class ValidationTestCase extends LaravelTestCase
      * Validate input using given validation rule, expect pass
      *
      * @param mixed $input
-     * @param Rule $rule
+     * @param Rule|ValidationRule $rule
      *
      * @throws ValidationException
      */
-    public function shouldPass($input, Rule $rule)
+    public function shouldPass(mixed $input, Rule|ValidationRule $rule): void
     {
         $validator = $this->makeValidator([ 'input' => $input ], [ 'input' => $rule ]);
 
@@ -72,11 +73,11 @@ abstract class ValidationTestCase extends LaravelTestCase
      * Validate input using given validation rule, expect not to pass
      *
      * @param mixed $input
-     * @param Rule $rule
+     * @param Rule|ValidationRule $rule
      *
      * @throws ValidationException
      */
-    public function shouldNotPass($input, Rule $rule)
+    public function shouldNotPass(mixed $input, Rule|ValidationRule $rule): void
     {
         $this->expectException(ValidationException::class);
 


### PR DESCRIPTION
PR adds `DateFormat` validation rule, which is able to handle an edge-case that concerns UTC time-zone offset, where the format might use the [`p` token](https://www.php.net/manual/en/datetime.format.php), but the date in question might contain `+00:00` as offset. 

Furthermore, the `DateFilter` and `DateTimeFilter` now use the new validation rule, instead of previous [`date_format`](https://laravel.com/docs/10.x/validation#rule-date-format) rule.