### PR TITLE
FIx/Improve infection free validaiton rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* `InfectionFreeFile` throws exception when invalid file is attempted scanned (_in the AntiVirus package_). [#180](https://github.com/aedart/athenaeum/issues/180).
+
 ## [7.22.0] - 2023-09-01
 
 ### Changed

--- a/packages/Antivirus/lang/en/antivirus.php
+++ b/packages/Antivirus/lang/en/antivirus.php
@@ -10,4 +10,5 @@ return [
     */
 
     'infected' => ':attribute appears to be infected with a virus, malware or other harmful software!',
+    'invalid_file' => 'The :attribute field appears to be invalid and cannot be read.',
 ];

--- a/packages/Antivirus/src/Scanners/Concerns/Streams.php
+++ b/packages/Antivirus/src/Scanners/Concerns/Streams.php
@@ -109,7 +109,7 @@ trait Streams
         } catch (Throwable $e) {
             throw new UnableToOpenFileStream(sprintf(
                 'Unable to open stream for file path %s',
-                $path
+                var_export($path, true)
             ), $e->getCode(), $e);
         }
     }
@@ -130,7 +130,7 @@ trait Streams
         } catch (Throwable $e) {
             throw new UnableToOpenFileStream(sprintf(
                 'Unable to open stream for file %s',
-                $file->getFilename()
+                var_export($file->getFilename(), true)
             ), $e->getCode(), $e);
         }
     }
@@ -185,7 +185,7 @@ trait Streams
         } catch (Throwable $e) {
             throw new UnableToOpenFileStream(sprintf(
                 'Unable to open stream for uploaded file %s',
-                $file->getClientFilename()
+                var_export($file->getClientFilename(), true)
             ), $e->getCode(), $e);
         }
     }

--- a/packages/Antivirus/src/Validation/Rules/InfectionFreeFile.php
+++ b/packages/Antivirus/src/Validation/Rules/InfectionFreeFile.php
@@ -2,6 +2,7 @@
 
 namespace Aedart\Antivirus\Validation\Rules;
 
+use Aedart\Antivirus\Exceptions\UnableToOpenFileStream;
 use Aedart\Antivirus\Facades\Antivirus;
 use Aedart\Contracts\Antivirus\Exceptions\AntivirusException;
 use Aedart\Contracts\Streams\FileStream;
@@ -52,9 +53,16 @@ class InfectionFreeFile extends BaseValidationRule
             options: $this->options()
         );
 
-        if (!$scanner->isClean($value)) {
-            $fail('athenaeum::antivirus.infected')->translate([ 'attribute' => $attribute ]);
+        try {
+            if (!$scanner->isClean($value)) {
+                $fail('athenaeum::antivirus.infected')->translate([ 'attribute' => $attribute ]);
+            }
+        } catch (UnableToOpenFileStream $e) {
+            // Fail validation whenever the file in question cannot be opened.
+            $fail('athenaeum::antivirus.invalid_file')->translate([ 'attribute' => $attribute ]);
         }
+
+        // Any other kind of exception SHOULD NOT be handled by this validation rule...
     }
 
     /**

--- a/tests/Integration/Antivirus/Validation/Rules/InfectionFreeFileRuleTest.php
+++ b/tests/Integration/Antivirus/Validation/Rules/InfectionFreeFileRuleTest.php
@@ -223,4 +223,54 @@ class InfectionFreeFileRuleTest extends AntivirusTestCase
             //->dump()
             ->assertNoContent();
     }
+
+    /**
+     * @test
+     *
+     * @return void
+     *
+     * @throws JsonException
+     */
+    public function failsWhenInvalidFilePathGiven(): void
+    {
+        Route::post('/files', function (Request $request) {
+            $request->validate([
+                'file' => [
+                    'nullable',
+                    'file',
+                    $this->makeRule(true) // "shouldPass" does not apply for this test...
+                ]
+            ]);
+
+            return response()->noContent();
+        })->name('file.upload');
+
+        Route::getRoutes()->refreshNameLookups();
+
+        // ----------------------------------------------------------------- //
+
+        // NOTE: Invalid "file" to trigger underlying "unable to open stream..." exception, and thereby
+        // validation failure.
+        $file = 'null';
+
+        // ----------------------------------------------------------------- //
+
+//        $this->withoutExceptionHandling();
+
+        $url = route('file.upload');
+        $response = $this
+            ->post($url, [
+                'file' => $file
+            ], [ 'accept' => 'application/json' ])
+            //->dump()
+            ->assertUnprocessable()
+            ->assertJson(
+                fn (AssertableJson $json) =>
+                $json
+                    ->has('errors.file')
+                    ->etc()
+            );
+
+        Response::decode($response);
+    }
 }


### PR DESCRIPTION
PR fixes #180. The `InfectionFreeFile` validation rule no longer throws an exception whenever an invalid file is attempted scanned. The rule will now just fail the validation is a new error message.

## Details

A new error message has been added (_key `athenaeum::antivirus.invalid_file`_).

## References

* #180 
