### PR TITLE
Improve flysystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Updated dependencies (_service update_).
+* `\Aedart\Tests\Integration\Flysystem\Db\Storage\StorageDiskTest::getEnvironmentSetUp()` now uses the default database connection.
+
+### Fixed
+
+* `fclose()`: supplied resource is not a valid stream resource when attempting to copy a stream, in `DatabaseAdapter` (_psql connections were affected_).
+* `DatabaseAdapter::createDirectory()` fails when attempting to create directories that already exists (_mariadb connections were affected_).
+* Incorrect dummy file visibility when created, in `\Aedart\Tests\Integration\Flysystem\Db\Adapters\D0_FileVisibilityTest::canSetVisibilityForFile()` (_mariadb connection was affected_)
+* Incorrect test assertion of file contents, in `\Aedart\Tests\Integration\Flysystem\Db\Adapters\C0_WriteFilesTest::canUpdateFile()` (_psql connection was affected_).
 
 ## [8.3.0] - 2024-05-07
 

--- a/packages/Flysystem/Db/src/Adapters/DatabaseAdapter.php
+++ b/packages/Flysystem/Db/src/Adapters/DatabaseAdapter.php
@@ -340,23 +340,20 @@ class DatabaseAdapter implements
             }
 
             // Upsert directories - create them if they do not exist,
-            // or update them, if already created.
-            $result = $connection
+            // or update them, if already created. Ignore amount of
+            // affected records (directories might already exist).
+            $connection
                 ->table($this->filesTable)
                 ->upsert(
                     values: $records,
                     uniqueBy: ['path'],
                     update: [
-                            'level',
-                            'visibility',
-                            'last_modified',
-                            'extra_metadata'
-                        ]
+                        'level',
+                        'visibility',
+                        'last_modified',
+                        'extra_metadata'
+                    ]
                 );
-
-            if (!$result) {
-                throw UnableToCreateDirectory::atLocation($path, sprintf('Directory was not created in table: %s', $this->filesTable));
-            }
         } catch (Throwable $e) {
             throw UnableToCreateDirectory::dueToFailure($path, $e);
         }

--- a/packages/Flysystem/Db/src/Adapters/DatabaseAdapter.php
+++ b/packages/Flysystem/Db/src/Adapters/DatabaseAdapter.php
@@ -355,7 +355,7 @@ class DatabaseAdapter implements
                 );
 
             if (!$result) {
-                throw new RuntimeException(sprintf('Directory was not created in table: %s', $this->filesTable));
+                throw UnableToCreateDirectory::atLocation($path, sprintf('Directory was not created in table: %s', $this->filesTable));
             }
         } catch (Throwable $e) {
             throw UnableToCreateDirectory::dueToFailure($path, $e);

--- a/packages/Flysystem/Db/src/Adapters/DatabaseAdapter.php
+++ b/packages/Flysystem/Db/src/Adapters/DatabaseAdapter.php
@@ -200,10 +200,7 @@ class DatabaseAdapter implements
                 throw new RuntimeException('Unable to read file contents');
             }
 
-            $wasClosed = fclose($resource);
-            if (!$wasClosed) {
-                throw new RuntimeException('Failed to close file contents stream.');
-            }
+            $this->closeStream($resource);
 
             return $content;
         } catch (Throwable $e) {
@@ -856,7 +853,7 @@ class DatabaseAdapter implements
         if (is_resource($contents)) {
             $this->writeStream($destination, $contents, $config);
 
-            fclose($contents);
+            $this->closeStream($contents);
         } else {
             $this->write($destination, $contents, $config);
         }
@@ -960,6 +957,25 @@ class DatabaseAdapter implements
                 ->positionToStart()
                 ->resource()
         ];
+    }
+
+    /**
+     * Closes given stream, if it's a resources. Fails if unable to close.
+     *
+     * @param resource $stream
+     *
+     * @return void
+     */
+    protected function closeStream($stream): void
+    {
+        if (!is_resource($stream)) {
+            return;
+        }
+
+        $wasClosed = fclose($stream);
+        if (!$wasClosed) {
+            throw new RuntimeException('Failed to close stream.');
+        }
     }
 
     /**

--- a/packages/Flysystem/Db/src/Adapters/DatabaseAdapter.php
+++ b/packages/Flysystem/Db/src/Adapters/DatabaseAdapter.php
@@ -371,13 +371,16 @@ class DatabaseAdapter implements
         try {
             $path = $this->applyPrefix($path);
 
-            // Change the path's visibility. Ignore affected records,...
-            $this
+            $affected = $this
                 ->resolveConnection()
                 ->table($this->filesTable)
                 ->where('path', $path)
                 ->limit(1)
                 ->update(['visibility' => $visibility]);
+
+            if ($affected === 0) {
+                throw new RuntimeException(sprintf('Visibility was not changed. Unable to find file or directory: %s', $path));
+            }
         } catch (Throwable $e) {
             throw UnableToSetVisibility::atLocation($path, $e->getMessage(), $e);
         }

--- a/packages/Flysystem/Db/src/Adapters/DatabaseAdapter.php
+++ b/packages/Flysystem/Db/src/Adapters/DatabaseAdapter.php
@@ -371,16 +371,13 @@ class DatabaseAdapter implements
         try {
             $path = $this->applyPrefix($path);
 
-            $affected = $this
+            // Change the path's visibility. Ignore affected records,...
+            $this
                 ->resolveConnection()
                 ->table($this->filesTable)
                 ->where('path', $path)
                 ->limit(1)
                 ->update(['visibility' => $visibility]);
-
-            if ($affected === 0) {
-                throw new RuntimeException(sprintf('Visibility was not changed. Unable to find file or directory: %s', $path));
-            }
         } catch (Throwable $e) {
             throw UnableToSetVisibility::atLocation($path, $e->getMessage(), $e);
         }

--- a/tests/Integration/Flysystem/Db/Adapters/C0_WriteFilesTest.php
+++ b/tests/Integration/Flysystem/Db/Adapters/C0_WriteFilesTest.php
@@ -4,6 +4,7 @@ namespace Aedart\Tests\Integration\Flysystem\Db\Adapters;
 
 use Aedart\Testing\Helpers\ConsoleDebugger;
 use Aedart\Tests\TestCases\Flysystem\Db\FlysystemDbTestCase;
+use RuntimeException;
 
 /**
  * C0_WriteFilesTest
@@ -187,6 +188,14 @@ class C0_WriteFilesTest extends FlysystemDbTestCase
         $this->assertSame(1, (int) $contentsList[0]->reference_count, 'Invalid reference_count');
 
         $this->assertSame($contentB, $fs->read($path), 'Incorrect content retrieved via filesystem');
-        $this->assertSame($contentB, $contentsList[0]->contents, 'Incorrect content in contents-table!');
+
+        $target = $contentsList[0]->contents;
+        $contents = match(true) {
+            is_resource($target) => stream_get_contents($target),
+            is_string($target) => $target,
+            default => throw new RuntimeException(sprintf('Unknown contents type: %s', gettype($target)))
+        };
+
+        $this->assertSame($contentB, $contents, 'Incorrect content in contents-table!');
     }
 }

--- a/tests/Integration/Flysystem/Db/Adapters/C0_WriteFilesTest.php
+++ b/tests/Integration/Flysystem/Db/Adapters/C0_WriteFilesTest.php
@@ -190,7 +190,7 @@ class C0_WriteFilesTest extends FlysystemDbTestCase
         $this->assertSame($contentB, $fs->read($path), 'Incorrect content retrieved via filesystem');
 
         $target = $contentsList[0]->contents;
-        $contents = match(true) {
+        $contents = match (true) {
             is_resource($target) => stream_get_contents($target),
             is_string($target) => $target,
             default => throw new RuntimeException(sprintf('Unknown contents type: %s', gettype($target)))

--- a/tests/Integration/Flysystem/Db/Adapters/D0_FileVisibilityTest.php
+++ b/tests/Integration/Flysystem/Db/Adapters/D0_FileVisibilityTest.php
@@ -4,6 +4,7 @@ namespace Aedart\Tests\Integration\Flysystem\Db\Adapters;
 
 use Aedart\Contracts\Flysystem\Visibility;
 use Aedart\Tests\TestCases\Flysystem\Db\FlysystemDbTestCase;
+use League\Flysystem\Config;
 use League\Flysystem\InvalidVisibilityProvided;
 
 /**
@@ -55,7 +56,9 @@ class D0_FileVisibilityTest extends FlysystemDbTestCase
         // ----------------------------------------------------------------- //
 
         $fs = $this->filesystem();
-        $fs->write($path, $content);
+        $fs->write($path, $content, [
+            Config::OPTION_VISIBILITY => 'public'
+        ]);
 
         $fs->setVisibility($path, Visibility::PRIVATE->value);
 

--- a/tests/Integration/Flysystem/Db/Storage/StorageDiskTest.php
+++ b/tests/Integration/Flysystem/Db/Storage/StorageDiskTest.php
@@ -33,7 +33,7 @@ class StorageDiskTest extends FlysystemDbTestCase
         // Add database storage disk to configuration.
         $app['config']->set('filesystems.disks.database', [
             'driver' => 'database',
-            'connection' => 'testing',
+            'connection' => $app['config']->get('database.default', 'testing'),
             'files_table' => 'files',
             'contents_table' => 'file_contents',
             'hash_algo' => 'sha256',

--- a/tests/TestCases/Flysystem/Db/FlysystemDbTestCase.php
+++ b/tests/TestCases/Flysystem/Db/FlysystemDbTestCase.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\DB;
 use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
+use PDO;
 
 /**
  * Flysystem Db Test Case
@@ -74,7 +75,45 @@ abstract class FlysystemDbTestCase extends FlysystemTestCase
      */
     protected function getEnvironmentSetUp($app)
     {
+        // sqlite (memory)
         TestingConnection::enableConnection();
+
+        // Postgresql
+        //        TestingConnection::enableConnection('pgsql', [
+        //            'driver' => 'pgsql',
+        //            //'url' => env('DB_URL'),
+        //            'host' => '127.0.0.1',
+        //            'port' => '5432',
+        //            'database' => 'laravel',
+        //            'username' => 'root',
+        //            'password' => 'secret',
+        //            'charset' => 'utf8',
+        //            'prefix' => '',
+        //            'prefix_indexes' => true,
+        //            'search_path' => 'public',
+        //            'sslmode' => 'prefer',
+        //        ]);
+
+        // MariaDB
+        //        TestingConnection::enableConnection('mariadb', [
+        //            'driver' => 'mariadb',
+        //            // 'url' => env('DB_URL'),
+        //            'host' => '127.0.0.1',
+        //            'port' => '3306',
+        //            'database' => 'laravel',
+        //            'username' => 'root',
+        //            'password' => 'secret',
+        //            'unix_socket' => '',
+        //            'charset' => 'utf8mb4',
+        //            'collation' => 'utf8mb4_unicode_ci',
+        //            'prefix' => '',
+        //            'prefix_indexes' => true,
+        //            'strict' => true,
+        //            'engine' => null,
+        //            'options' => extension_loaded('pdo_mysql') ? array_filter([
+        //                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+        //            ]) : [],
+        //        ]);
     }
 
     /**


### PR DESCRIPTION
PR fixes two minor issues with the flyssystem `DatabaseAdapter`:

* `fclose()` was supplied with invalid resource stream when attempting to copy a stream (_affected psql connections_).
* `DatabaseAdapter::createDirectory()` failed when attempting to create directories that already existed (_affected mariadb connections_).

In addition to the above, a few test assertions where improved.

## Details

Sqlite, Postgresql and MariaDB were tested locally, before this PR was submitted. The reported issue #189 could not be confirmed for the following environment:
- PHP v8.2
- Laravel v11.8
- league/flysystem v3.28

## References

* #189 
