### PR TITLE
Fix mime type sample size

### DIFF
--- a/packages/MimeTypes/src/Drivers/BaseSampler.php
+++ b/packages/MimeTypes/src/Drivers/BaseSampler.php
@@ -90,7 +90,7 @@ abstract class BaseSampler implements Sampler
      */
     public function getSampleSize(): int
     {
-        if (!isset($this->sampleSize) || $this->sampleSize === 0) {
+        if (empty($this->sampleSize)) {
             $this->setSampleSize($this->get('sample_size', 0));
         }
 

--- a/packages/MimeTypes/src/Drivers/BaseSampler.php
+++ b/packages/MimeTypes/src/Drivers/BaseSampler.php
@@ -90,7 +90,7 @@ abstract class BaseSampler implements Sampler
      */
     public function getSampleSize(): int
     {
-        if (!isset($this->sampleSize)) {
+        if (!isset($this->sampleSize) || $this->sampleSize === 0) {
             $this->setSampleSize($this->get('sample_size', 0));
         }
 

--- a/tests/Integration/MimeTypes/DetectorTest.php
+++ b/tests/Integration/MimeTypes/DetectorTest.php
@@ -103,4 +103,22 @@ class DetectorTest extends MimeTypesTestCase
             ->getMimeTypeDetector()
             ->detectForFile('some_unknown_file.txt');
     }
+
+    /**
+     * @test
+     *
+     * @return void
+     *
+     * @throws MimeTypeDetectionException
+     */
+    public function hasSampleSizeSetInSample(): void
+    {
+        // When using inside Laravel, a default sample size SHOULD be
+        // set automatically.
+        // @see https://github.com/aedart/athenaeum/issues/191
+        $stream = $this->getFileStream('txt');
+        $sampler = $this->getMimeTypeDetector()->makeSampler($stream);
+
+        $this->assertGreaterThan(0, $sampler->getSampleSize());
+    }
 }

--- a/tests/_data/configs/mime-types/mime-types-detection.php
+++ b/tests/_data/configs/mime-types/mime-types-detection.php
@@ -42,7 +42,7 @@ return [
             'driver' => \Aedart\MimeTypes\Drivers\FileInfoSampler::class,
             'options' => [
 //                'sample_size' => 1048576,
-                'sample_size' => \Aedart\Contracts\Streams\BufferSizes::BUFFER_1KB / 2,
+                'sample_size' => \Aedart\Contracts\Streams\BufferSizes::BUFFER_128KB,
                 'magic_database' => null
             ]
         ]


### PR DESCRIPTION
Fixes issue where a default sample size is not respected by Mime Type detector's sampler.

## Details

See #191 for details.
