### PR TITLE
Fix unable to read file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Updated dependencies (_service update_).
 
+### Fixed
+
+* `DatabaseAdapter` fails when attempting to move or copy to the same destination as the source (_adapter now skips performing `move()` or `copy()`, if source and destination are the same_). [#195](https://github.com/aedart/athenaeum/issues/195).
+
 ## [8.10.0] - 2024-09-23
 
 ### Changed

--- a/packages/Flysystem/Db/src/Adapters/DatabaseAdapter.php
+++ b/packages/Flysystem/Db/src/Adapters/DatabaseAdapter.php
@@ -471,6 +471,11 @@ class DatabaseAdapter implements
      */
     public function move(string $source, string $destination, Config $config): void
     {
+        // Skip when source and destination are the same...
+        if ($source === $destination) {
+            return;
+        }
+
         try {
             // Copy the file
             $this->performCopy($source, $destination, $config);
@@ -487,6 +492,11 @@ class DatabaseAdapter implements
      */
     public function copy(string $source, string $destination, Config $config): void
     {
+        // Skip when source and destination are the same...
+        if ($source === $destination) {
+            return;
+        }
+
         try {
             $this->performCopy($source, $destination, $config);
         } catch (Throwable $e) {


### PR DESCRIPTION
Fixes #195 

## Details

The `DatabaseAdapter` failed to move or copy a file, if the source and destination where the same.
Now, the adapter simply skips attempting to move or copy a file, if the source and destination paths are the same.
