### PR TITLE
Fix "capture fields to select" middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* `TypeError` thrown in `CaptureFieldsToSelect` middleware, when "select" query parameter is not a string. [#197](https://github.com/aedart/athenaeum/issues/197).
+
 ## [8.12.0] - 2024-10-21
 
 ### Changed

--- a/tests/Integration/Http/Api/Middleware/CaptureFieldsToSelectMiddlewareTest.php
+++ b/tests/Integration/Http/Api/Middleware/CaptureFieldsToSelectMiddlewareTest.php
@@ -6,9 +6,13 @@ use Aedart\Contracts\Http\Api\SelectedFieldsCollection;
 use Aedart\Http\Api\Middleware\CaptureFieldsToSelect;
 use Aedart\Support\Facades\IoCFacade;
 use Aedart\Testing\Helpers\ConsoleDebugger;
+use Aedart\Tests\Helpers\Dummies\Http\Api\Models\User;
+use Aedart\Tests\Helpers\Dummies\Http\Api\Requests\Users\ListUsersRequest;
+use Aedart\Tests\Helpers\Dummies\Http\Api\Resources\UserResource;
 use Aedart\Tests\TestCases\Http\ApiResourcesTestCase;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Validation\ValidationException;
 
 /**
@@ -158,9 +162,50 @@ class CaptureFieldsToSelectMiddlewareTest extends ApiResourcesTestCase
 
         $request = new Request([ 'select' => implode(',', $requestedFields) ]);
 
-        (new CaptureFieldsToSelect())->handle($request, function () use (&$result) {
+        (new CaptureFieldsToSelect())->handle($request, function () {
             $result = IoCFacade::tryMake(SelectedFieldsCollection::class);
             return new Response();
         });
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     *
+     * @throws ValidationException
+     */
+    public function doesNotFailWhenFieldsRequestedAsAnArray(): void
+    {
+        // @see https://github.com/aedart/athenaeum/issues/197
+
+        /** @var SelectedFieldsCollection|null $result */
+        $result = null;
+
+        Route::get('/users', function (Request $request) use(&$result) {
+            $result = IoCFacade::tryMake(SelectedFieldsCollection::class);
+
+            return new Response();
+        })
+            ->middleware(CaptureFieldsToSelect::class)
+            ->name('users.index');
+
+        Route::getRoutes()->refreshNameLookups();
+
+        // ------------------------------------------------------------------------------------ //
+
+        $url = route('users.index') . '?select[0]=id&select[1]=user&select[2]=details';
+        $this
+            ->getJson($url)
+            ->assertOk();
+
+        // ------------------------------------------------------------------------------------ //
+
+        ConsoleDebugger::output($result);
+
+        $this->assertNotNull($result, 'no fields collection registered');
+        $this->assertTrue($result->has('id'), '"id" field not available');
+        $this->assertTrue($result->has('user'), '"user" field not available');
+        $this->assertTrue($result->has('details'), '"details" field not available');
     }
 }


### PR DESCRIPTION
Fixes #197

The middlware is now able to accept string and array input. However, in case of other types, the middleware throws a HTTP "400 Bad Request" exception.