### PR TITLE
Use json_validate() in Json::isValid()

### DIFF
--- a/CHANGELOG_v9x.md
+++ b/CHANGELOG_v9x.md
@@ -4,6 +4,10 @@ TODO: Temporary changelog file for the upcoming major version `9.x`.
 
 ## [Unreleased]
 
+### Added
+
+* `Json::isValid()` now accepts `$depth` and `$options` parameters.
+
 ### Changed
 
 **Breaking Changes**
@@ -13,7 +17,7 @@ TODO: Temporary changelog file for the upcoming major version `9.x`.
 
 **Non-breaking Changes**
 
-* N/A
+* Now using native `json_validate()`, in `\Aedart\Utils\Json::isValid`. [#120](https://github.com/aedart/athenaeum/issues/120).
 
 
 ### Fixed

--- a/packages/Utils/src/Json.php
+++ b/packages/Utils/src/Json.php
@@ -62,18 +62,20 @@ class Json
     /**
      * Determine if given value is a valid json encoded string
      *
-     * @param  mixed  $value
+     * @link https://www.php.net/manual/en/function.json-validate.php
+     *
+     * @param mixed $value
+     * @param int $depth [optional] Recursion depth
+     * @param int $options [optional] Flags
      *
      * @return bool False if not a string or if invalid encoded json
      */
-    public static function isValid(mixed $value): bool
+    public static function isValid(mixed $value, int $depth = 512, int $options = 0): bool
     {
         if (!is_string($value)) {
             return false;
         }
 
-        @json_decode($value);
-
-        return json_last_error() === JSON_ERROR_NONE;
+        return json_validate($value, $depth, $options);
     }
 }


### PR DESCRIPTION
`Json::isValid()` now uses PHP's native `json_validate()` for validating json strings. In addition, `$depth` and `$options` parameters are now supported by `isValid()`.

## References

#120 
