### PR TITLE
Upgrade php stan to version 2.x

### DIFF
--- a/CHANGELOG_v9x.md
+++ b/CHANGELOG_v9x.md
@@ -17,7 +17,7 @@ TODO: Temporary changelog file for the upcoming major version `9.x`.
 
 * Minimum required PHP version changed to `v8.3`.
 * Adapted CI environment to test PHP `v8.3` and `v8.4`.
-* Upgraded to use PHPStan `v2.x`
+* Upgraded to use PHPStan `v2.x` [#200](https://github.com/aedart/athenaeum/issues/200).
 
 **Non-breaking Changes**
 

--- a/CHANGELOG_v9x.md
+++ b/CHANGELOG_v9x.md
@@ -17,6 +17,7 @@ TODO: Temporary changelog file for the upcoming major version `9.x`.
 
 * Minimum required PHP version changed to `v8.3`.
 * Adapted CI environment to test PHP `v8.3` and `v8.4`.
+* Upgraded to use PHPStan `v2.x`
 
 **Non-breaking Changes**
 

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "nette/neon": "^3.4.4",
         "orchestra/testbench": "^v9.9.0",
         "orchestra/testbench-dusk": "^v9.11.2",
-        "phpstan/phpstan": "^1.12.17",
+        "phpstan/phpstan": "^2.1.4",
         "predis/predis": "^2.3.0",
         "roave/security-advisories": "dev-master",
         "symfony/var-dumper": "^v7.2.3",


### PR DESCRIPTION
PR upgrades [PHPStan](https://phpstan.org/) to `v2.x`.
 
## References

#200 
