### PR TITLE
Remove deprecated methods

### DIFF
--- a/CHANGELOG_v9x.md
+++ b/CHANGELOG_v9x.md
@@ -24,6 +24,7 @@ TODO: Temporary changelog file for the upcoming major version `9.x`.
 * Now using native `json_validate()`, in `\Aedart\Utils\Json::isValid`. [#120](https://github.com/aedart/athenaeum/issues/120).
 * "Split Packages" GitHub workflow no longer triggered in pull requests.
 * Class constants now have [types](https://php.watch/versions/8.3/typed-constants) declared.
+* `\Aedart\Console\Commands\PirateTalkCommand` now uses `\Aedart\Utils\Arr::randomizer()->value()` to pick random sentence.
 
 ### Fixed
 

--- a/CHANGELOG_v9x.md
+++ b/CHANGELOG_v9x.md
@@ -34,5 +34,5 @@ TODO: Temporary changelog file for the upcoming major version `9.x`.
 
 * `\Aedart\Auth\Fortify\Actions\RehashPasswordIfNeeded` (_was deprecated in Athenaeum `v8.x`_). [#182](https://github.com/aedart/athenaeum/issues/182).
 * `\Aedart\Auth\Fortify\Events\PasswordWasRehashed` (_was deprecated in Athenaeum `v8.x`_). [#182](https://github.com/aedart/athenaeum/issues/182).
-* `\Aedart\Utils\Arr::randomElement()` (_was deprecated in Athenaeum `v8.x`_)
-* `\Aedart\Utils\Math::randomInt()` (_was deprecated in Athenaeum `v8.x`_)
+* `\Aedart\Utils\Arr::randomElement()` (_was deprecated in Athenaeum `v8.x`_). Replaced by `\Aedart\Utils\Arr::randomizer()->value()`.
+* `\Aedart\Utils\Math::randomInt()` (_was deprecated in Athenaeum `v8.x`_). Replaced by `\Aedart\Utils\Math::randomizer()->int()`.

--- a/CHANGELOG_v9x.md
+++ b/CHANGELOG_v9x.md
@@ -34,3 +34,5 @@ TODO: Temporary changelog file for the upcoming major version `9.x`.
 
 * `\Aedart\Auth\Fortify\Actions\RehashPasswordIfNeeded` (_was deprecated in Athenaeum `v8.x`_). [#182](https://github.com/aedart/athenaeum/issues/182).
 * `\Aedart\Auth\Fortify\Events\PasswordWasRehashed` (_was deprecated in Athenaeum `v8.x`_). [#182](https://github.com/aedart/athenaeum/issues/182).
+* `\Aedart\Utils\Arr::randomElement()` (_was deprecated in Athenaeum `v8.x`_)
+* `\Aedart\Utils\Math::randomInt()` (_was deprecated in Athenaeum `v8.x`_)

--- a/docs/archive/next/upgrade-guide.md
+++ b/docs/archive/next/upgrade-guide.md
@@ -19,7 +19,15 @@ You need PHP `v8.3` or higher to run Athenaeum packages.
 
 Please read Laravel's [upgrade guide](https://laravel.com/docs/12.x/upgrade), before continuing here.
 
-...TODO
+### Removed `Arr::randomElement()`
+
+`\Aedart\Utils\Arr::randomElement()` was deprecated in `v8.x`. It has been replaced
+by `\Aedart\Utils\Arr::randomizer()->value()`.
+
+### Removed `Math::randomInt()`
+
+`\Aedart\Utils\Math::randomInt()` was deprecated in `v8.x`. It has been replaced
+by `\Aedart\Utils\Math::randomizer()->int()`.
 
 ## Onward
 

--- a/docs/archive/next/utils/array.md
+++ b/docs/archive/next/utils/array.md
@@ -9,40 +9,6 @@ Extended version of Laravel's [`Arr` component](https://laravel.com/docs/11.x/he
 
 [[TOC]]
 
-## `randomElement()`
-
-::: danger Deprecated
-The `randomElement()` is deprecated. Pleas use [`Arr::randomizer()->value()`](#value) instead.
-:::
-
-
-Returns a single random element from a given list.
-
-```php
-use Aedart\Utils\Arr;
-
-$element = Arr::randomElement(['Jim', 'Sine', 'Ally', 'Gordon']);
-```
-
-See also Laravel's [`Arr::random`](https://laravel.com/docs/11.x/helpers#method-array-random).
-
-### Seeding
-
-You can also provide a [seed for the random number generator](https://www.php.net/manual/en/function.mt-srand.php). 
-
-```php
-use Aedart\Utils\Arr;
-use Aedart\Utils\Math;
-
-$element = Arr::randomElement(
-    ['Jim', 'Sine', 'Ally', 'Gordon'],
-    Math::seed(),
-    MT_RAND_PHP
-);
-```
-
-See [`Math::seed()` and `Math::applySeed()` methods ](math.md) for additional information about seeding.
-
 ## `randomizer()`
 
 The `randomizer()` method returns a `ArrayRandomizer` component - an adapter for PHP [`Random\Randomizer`](https://www.php.net/manual/en/class.random-randomizer.php).

--- a/docs/archive/next/utils/math.md
+++ b/docs/archive/next/utils/math.md
@@ -9,20 +9,6 @@ Offers math related utility methods.
 
 [[TOC]]
 
-## `randomInt()`
-
-::: warning Deprecated
-The `randomInt()` method has been deprecated. Please use [`randomizer()`](#randomizer) instead.
-:::
-
-Generates a random number between given minimum and maximum values.
-
-```php
-use Aedart\Utils\Math;
-
-$value = Math::randomInt(1, 10);
-```
-
 ## `randomizer()`
 
 The `randomizer()` method returns a `NumericRandomizer` component - an adapter for PHP [`Random\Randomizer`](https://www.php.net/manual/en/class.random-randomizer.php).  

--- a/packages/Console/src/Commands/PirateTalkCommand.php
+++ b/packages/Console/src/Commands/PirateTalkCommand.php
@@ -4,6 +4,7 @@ namespace Aedart\Console\Commands;
 
 use Aedart\Utils\Arr;
 use Illuminate\Console\Command;
+use Throwable;
 
 /**
  * Pirate Talk Command
@@ -33,6 +34,8 @@ class PirateTalkCommand extends Command
      * Execute this command
      *
      * @return int
+     *
+     * @throws Throwable
      */
     public function handle(): int
     {
@@ -63,7 +66,7 @@ class PirateTalkCommand extends Command
         ];
 
         // Say something, you pirate!
-        $this->output->text(Arr::randomElement($sentences));
+        $this->output->text(Arr::randomizer()->value($sentences));
 
         return 0;
     }

--- a/packages/Utils/src/Arr.php
+++ b/packages/Utils/src/Arr.php
@@ -31,31 +31,6 @@ class Arr extends ArrBase
     }
 
     /**
-     * @deprecated Since v8.0 - Use \Aedart\Utils\Arr::randomizer()->value() instead.
-     *
-     * Returns a single random element from given list
-     *
-     * @see \Aedart\Utils\Math::applySeed
-     *
-     * @param array $list
-     * @param int|null $seed [optional] Number to seed the random generator.
-     * @param int $mode [optional] The seeding algorithm to use
-     *
-     * @return mixed
-     */
-    public static function randomElement(array $list, int|null $seed = null, int $mode = MT_RAND_MT19937): mixed
-    {
-        // Seed generator if required
-        if (isset($seed)) {
-            Math::applySeed($seed, $mode);
-        }
-
-        $index = array_rand($list, 1);
-
-        return $list[$index];
-    }
-
-    /**
      * Computes the difference of multidimensional arrays
      *
      * @param array $array The array to compare from

--- a/packages/Utils/src/Math.php
+++ b/packages/Utils/src/Math.php
@@ -30,33 +30,6 @@ class Math
     }
 
     /**
-     * @deprecated Since v8.0 - Use \Aedart\Utils\Math::randomizer()->int() instead.
-     *
-     * Returns a random cryptographically secure, uniformly selected number
-     *
-     * @see https://www.php.net/manual/en/function.random-int
-     *
-     * @param int $min [optional] Must be greater than or equals PHP_INT_MIN
-     * @param int $max [optional] Must be less than or equals PHP_INT_MAX
-     *
-     * @return int
-     *
-     * @throws RuntimeException If arguments are invalid or unable to generate enough randomness
-     */
-    public static function randomInt(int $min = PHP_INT_MIN, int $max = PHP_INT_MAX): int
-    {
-        try {
-            return random_int($min, $max);
-        } catch (Throwable $e) {
-            throw new RuntimeException(
-                'Unable to generate random number: ' . $e->getMessage(),
-                $e->getCode(),
-                $e
-            );
-        }
-    }
-
-    /**
      * Generates a seed that can be used for the random number generator
      *
      * @see applySeed

--- a/packages/Utils/src/Math.php
+++ b/packages/Utils/src/Math.php
@@ -6,8 +6,6 @@ use Aedart\Contracts\Utils\Random\NumericRandomizer;
 use Aedart\Contracts\Utils\Random\Type;
 use Aedart\Utils\Random\Factory;
 use Random\Engine;
-use RuntimeException;
-use Throwable;
 
 /**
  * Math Utility

--- a/tests/Unit/Utils/ArrTest.php
+++ b/tests/Unit/Utils/ArrTest.php
@@ -7,6 +7,8 @@ use Aedart\Contracts\Utils\Random\ArrayRandomizer;
 use Aedart\Testing\Helpers\ConsoleDebugger;
 use Aedart\Testing\TestCases\UnitTestCase;
 use Aedart\Utils\Arr;
+use Random\Engine\Mt19937;
+use Throwable;
 
 /**
  * ArrTest
@@ -33,16 +35,20 @@ class ArrTest extends UnitTestCase
 
     /**
      * @test
+     *
+     * @throws Throwable
      */
     public function returnsSameValueWhenSeededWithStaticValue()
     {
-        $list = range('a', 'z');
+        $list = [ 'a', 'b', 'c' ];
 
         $seed = 123456;
 
-        $resultA = Arr::randomElement($list, $seed);
-        $resultB = Arr::randomElement($list, $seed);
-        $resultC = Arr::randomElement($list, $seed);
+        $randomizer = Arr::randomizer(new Mt19937($seed));
+
+        $resultA = $randomizer->value($list);
+        $resultB = $randomizer->value($list);
+        $resultC = $randomizer->value($list);
 
         ConsoleDebugger::output($resultA, $resultB, $resultC);
 

--- a/tests/Unit/Utils/ArrTest.php
+++ b/tests/Unit/Utils/ArrTest.php
@@ -34,20 +34,6 @@ class ArrTest extends UnitTestCase
     /**
      * @test
      */
-    public function canObtainSingleRandomElement()
-    {
-        $list = range('a', 'z');
-
-        $result = Arr::randomElement($list);
-
-        ConsoleDebugger::output($result);
-
-        $this->assertTrue(in_array($result, $list));
-    }
-
-    /**
-     * @test
-     */
     public function returnsSameValueWhenSeededWithStaticValue()
     {
         $list = range('a', 'z');

--- a/tests/Unit/Utils/MathTest.php
+++ b/tests/Unit/Utils/MathTest.php
@@ -6,7 +6,7 @@ use Aedart\Contracts\Utils\Random\NumericRandomizer;
 use Aedart\Testing\Helpers\ConsoleDebugger;
 use Aedart\Testing\TestCases\UnitTestCase;
 use Aedart\Utils\Math;
-use RuntimeException;
+use ValueError;
 
 /**
  * MathTest
@@ -36,9 +36,9 @@ class MathTest extends UnitTestCase
      */
     public function failsRandomIntWhenInvalidArguments()
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(ValueError::class);
 
-        Math::randomInt(1, -1);
+        Math::randomizer()->int(1, -1);
     }
 
     /**

--- a/tests/Unit/Utils/MathTest.php
+++ b/tests/Unit/Utils/MathTest.php
@@ -34,22 +34,6 @@ class MathTest extends UnitTestCase
     /**
      * @test
      */
-    public function canGenerateRandomInt()
-    {
-        $resultA = Math::randomInt(0, 100);
-        $resultB = Math::randomInt(0, 100);
-        $resultC = Math::randomInt(0, 100);
-
-        ConsoleDebugger::output($resultA, $resultB, $resultC);
-
-        $this->assertGreaterThanOrEqual(0, $resultA);
-        $this->assertGreaterThanOrEqual(0, $resultB);
-        $this->assertGreaterThanOrEqual(0, $resultC);
-    }
-
-    /**
-     * @test
-     */
     public function failsRandomIntWhenInvalidArguments()
     {
         $this->expectException(RuntimeException::class);


### PR DESCRIPTION
PR removed the following deprecated methods:

* `\Aedart\Utils\Arr::randomElement()`. _Replaced by `\Aedart\Utils\Arr::randomizer()->value()`_.
* `\Aedart\Utils\Math::randomInt()`. _Replaced by `\Aedart\Utils\Math::randomizer()->int()`_.