### PR TITLE
Upgrade http response status dependency

### DIFF
--- a/CHANGELOG_v9x.md
+++ b/CHANGELOG_v9x.md
@@ -22,6 +22,7 @@ TODO: Temporary changelog file for the upcoming major version `9.x`.
 **Non-breaking Changes**
 
 * Now using native `json_validate()`, in `\Aedart\Utils\Json::isValid`. [#120](https://github.com/aedart/athenaeum/issues/120).
+* Upgraded to use `shrikeh/teapot` `v3.x`.
 * "Split Packages" GitHub workflow no longer triggered in pull requests.
 * Class constants now have [types](https://php.watch/versions/8.3/typed-constants) declared.
 * `\Aedart\Console\Commands\PirateTalkCommand` now uses `\Aedart\Utils\Arr::randomizer()->value()` to pick random sentence.

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "psr/http-message": "^1.1",
         "psr/log": "^3.0.2",
         "ramsey/http-range": "^1.1.0",
-        "shrikeh/teapot": "^2.3.1",
+        "shrikeh/teapot": "^3.0.0",
         "symfony/console": "^v7.2.1",
         "symfony/finder": "^7.2.2",
         "vlucas/phpdotenv": "^5.6.1",

--- a/docs/archive/next/http/clients/methods/expectations.md
+++ b/docs/archive/next/http/clients/methods/expectations.md
@@ -229,7 +229,8 @@ If you require a way to modify the incoming response or perhaps the outgoing req
 
 ## Status Code Object
 
-The `Status` object, that given to your expectation callbacks, offers a variety of methods to quickly determine if it matches a desired Http status code.
+The `Status` object that is provided offers a variety of methods to quickly determine if it matches a desired Http
+status code.
 
 ```php
 use Aedart\Contracts\Http\Clients\Responses\Status;
@@ -254,6 +255,10 @@ $client
         }
         
         if ( ! $status->isSuccessful()) {
+            // ...
+        }
+        
+        if ($status->isServerError()) {
             // ...
         }
     });

--- a/packages/Http/Api/composer.json
+++ b/packages/Http/Api/composer.json
@@ -23,7 +23,7 @@
         "aedart/athenaeum-support": "^8.22",
         "aedart/athenaeum-validation": "^8.22",
         "illuminate/http": "^v11.42.1",
-        "shrikeh/teapot": "^2.3.1"
+        "shrikeh/teapot": "^3.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/Http/Clients/composer.json
+++ b/packages/Http/Clients/composer.json
@@ -29,7 +29,7 @@
         "psr/http-client": "^1.0.3",
         "psr/http-factory": "^1.1.0",
         "psr/http-message": "^1.1",
-        "shrikeh/teapot": "^2.3.1"
+        "shrikeh/teapot": "^3.0.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
PR upgrades `shrikeh/teapot` to version `3.x`

## Details

Thought this could perhaps break something in the various packages - but lucky this didn't happen. It appears that `shrikeh/teapot` is fully backwards compatible with its `v2.x` series.
