### PR TITLE
Add auth components

### DIFF
--- a/CHANGELOG_v9x.md
+++ b/CHANGELOG_v9x.md
@@ -9,6 +9,8 @@ TODO: Temporary changelog file for the upcoming major version `9.x`.
 * `float()` and `nextFloat()` methods in `NumericRandomizer` (_in the Utils package_). [#184](https://github.com/aedart/athenaeum/issues/184)
 * `bytesFromString()` in `StringRandomizer` (_in the Utils package_). [#185](https://github.com/aedart/athenaeum/issues/185)
 * `Json::isValid()` now accepts `$depth` and `$options` parameters.
+* Custom `FailedPasswordResetLinkApiResponse` in `aedart/athenaeum-auth` package.
+* `FailedLoginAttempt` and `PasswordResetLinkFailure` exceptions in `aedart/athenaeum-auth` package.
 * `ConcurrencyManager`, `LogContextRepository`, `DateFactory`, `ExceptionHandler`, `ParallelTesting`, `ProcessFactory`, `RateLimiter`, `Schedule` and `Vite` aware-of helpers, in `Aedart\Support\Helpers`.
 * Configuration for `composer-bin-plugin` (_in root `composer.json`_).
 
@@ -28,6 +30,7 @@ TODO: Temporary changelog file for the upcoming major version `9.x`.
 
 * Now using native `json_validate()`, in `\Aedart\Utils\Json::isValid`. [#120](https://github.com/aedart/athenaeum/issues/120).
 * Upgraded to use `shrikeh/teapot` `v3.x`.
+* `aedart/athenaeum-auth` package now depends on `laravel/fortify` and `illuminate/validation`
 * "Split Packages" GitHub workflow no longer triggered in pull requests.
 * Class constants now have [types](https://php.watch/versions/8.3/typed-constants) declared.
 * `\Aedart\Console\Commands\PirateTalkCommand` now uses `\Aedart\Utils\Arr::randomizer()->value()` to pick random sentence.

--- a/packages/Auth/composer.json
+++ b/packages/Auth/composer.json
@@ -17,7 +17,10 @@
     "require": {
         "php": "^8.3",
         "aedart/athenaeum-contracts": "^8.22",
-        "aedart/athenaeum-support": "^8.22"
+        "aedart/athenaeum-support": "^8.22",
+        "laravel/fortify": "^1.25.4",
+        "illuminate/validation": "^v12.0.1",
+        "shrikeh/teapot": "^3.0.0"
     },
     "require-dev": {
         "laravel/fortify": "^1.25.4"

--- a/packages/Auth/src/Fortify/Exceptions/FailedLoginAttempt.php
+++ b/packages/Auth/src/Fortify/Exceptions/FailedLoginAttempt.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Aedart\Auth\Fortify\Exceptions;
+
+use Illuminate\Validation\ValidationException;
+use Teapot\StatusCode\All as Status;
+
+/**
+ * Failed Login Attempt Exception
+ *
+ * Should be thrown whenever a login attempt has failed.
+ *
+ * @author Alin Eugen Deac <ade@rspsystems.com>
+ * @package Aedart\Auth\Fortify\Exceptions
+ */
+class FailedLoginAttempt extends ValidationException
+{
+    /**
+     * The status code to use for the response.
+     *
+     * @var int
+     */
+    public $status = Status::UNAUTHORIZED;
+}

--- a/packages/Auth/src/Fortify/Exceptions/PasswordResetLinkFailure.php
+++ b/packages/Auth/src/Fortify/Exceptions/PasswordResetLinkFailure.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Aedart\Auth\Fortify\Exceptions;
+
+use Illuminate\Validation\ValidationException;
+use Teapot\StatusCode\All as Status;
+
+/**
+ * Password Reset Link Failure Exception
+ *
+ * Intended to be thrown whenever an incorrect email is provided by the client, in the context
+ * of attempting to reset a user's password.
+ *
+ * @see \Illuminate\Contracts\Auth\PasswordBroker::INVALID_USER
+ * @see \Laravel\Fortify\Contracts\FailedPasswordResetLinkRequestResponse
+ * @see \Aedart\Auth\Fortify\Responses\FailedPasswordResetLinkRequestResponse
+ *
+ * @author Alin Eugen Deac <ade@rspsystems.com>
+ * @package Aedart\Auth\Fortify\Exceptions
+ */
+class PasswordResetLinkFailure extends ValidationException
+{
+    /**
+     * The status code to use for the response.
+     *
+     * Normally, a "422 Unprocessable Entity" error is returned to the client whenever an incorrect
+     * email is requested. In an edge case, this could be used to determine if an email exists in
+     * the application, by a malicious user. Therefore, here we simply switch to respond "200 Ok"!
+     *
+     * @var int
+     */
+    public $status = Status::OK;
+}

--- a/packages/Auth/src/Fortify/Exceptions/PasswordResetLinkFailure.php
+++ b/packages/Auth/src/Fortify/Exceptions/PasswordResetLinkFailure.php
@@ -13,7 +13,7 @@ use Teapot\StatusCode\All as Status;
  *
  * @see \Illuminate\Contracts\Auth\PasswordBroker::INVALID_USER
  * @see \Laravel\Fortify\Contracts\FailedPasswordResetLinkRequestResponse
- * @see \Aedart\Auth\Fortify\Responses\FailedPasswordResetLinkRequestResponse
+ * @see \Aedart\Auth\Fortify\Responses\FailedPasswordResetLinkApiResponse
  *
  * @author Alin Eugen Deac <ade@rspsystems.com>
  * @package Aedart\Auth\Fortify\Exceptions

--- a/packages/Auth/src/Fortify/Responses/FailedPasswordResetLinkApiResponse.php
+++ b/packages/Auth/src/Fortify/Responses/FailedPasswordResetLinkApiResponse.php
@@ -13,7 +13,7 @@ use Laravel\Fortify\Http\Responses\FailedPasswordResetLinkRequestResponse as Bas
  * @author Alin Eugen Deac <ade@rspsystems.com>
  * @package Aedart\Auth\Fortify\Responses
  */
-class FailedPasswordResetLinkRequestResponse extends BaseResponse
+class FailedPasswordResetLinkApiResponse extends BaseResponse
 {
     /**
      * @inheritdoc
@@ -29,7 +29,8 @@ class FailedPasswordResetLinkRequestResponse extends BaseResponse
             throw PasswordResetLinkFailure::withMessages([]);
         }
 
-        // Otherwise, redirect to the previous URL (original behaviour...)
+        // Otherwise, redirect to the previous URL (original behaviour...).
+        // CAUTION: This can reveal that the user does not exist!
         return back()
             ->withInput($request->only('email'))
             ->withErrors(['email' => trans($this->status)]);

--- a/packages/Auth/src/Fortify/Responses/FailedPasswordResetLinkRequestResponse.php
+++ b/packages/Auth/src/Fortify/Responses/FailedPasswordResetLinkRequestResponse.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Aedart\Auth\Fortify\Responses;
+
+use Aedart\Auth\Fortify\Exceptions\PasswordResetLinkFailure;
+use Laravel\Fortify\Http\Responses\FailedPasswordResetLinkRequestResponse as BaseResponse;
+
+/**
+ * Failed Password Reset Link Request Response
+ *
+ * @see \Laravel\Fortify\Contracts\FailedPasswordResetLinkRequestResponse
+ *
+ * @author Alin Eugen Deac <ade@rspsystems.com>
+ * @package Aedart\Auth\Fortify\Responses
+ */
+class FailedPasswordResetLinkRequestResponse extends BaseResponse
+{
+    /**
+     * @inheritdoc
+     *
+     * @throws PasswordResetLinkFailure
+     */
+    public function toResponse($request)
+    {
+        // In case that request was performed by an API Client (json), simply fail silently,
+        // without any error messages. See the `PasswordResetLinkFailure` for details!
+
+        if ($request->wantsJson()) {
+            throw PasswordResetLinkFailure::withMessages([]);
+        }
+
+        // Otherwise, redirect to the previous URL (original behaviour...)
+        return back()
+            ->withInput($request->only('email'))
+            ->withErrors(['email' => trans($this->status)]);
+    }
+}

--- a/tests/Integration/Auth/Fortify/FailedPasswordResetLinkApiResponseTest.php
+++ b/tests/Integration/Auth/Fortify/FailedPasswordResetLinkApiResponseTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Aedart\Tests\Integration\Auth\Fortify;
+
+use Aedart\Auth\Fortify\Exceptions\PasswordResetLinkFailure;
+use Aedart\Auth\Fortify\Responses\FailedPasswordResetLinkApiResponse;
+use Aedart\Tests\TestCases\Auth\FortifyTestCase;
+use Illuminate\Contracts\Auth\PasswordBroker;
+use Illuminate\Support\Facades\Request;
+
+/**
+ * FailedPasswordResetLinkApiResponseTest
+ *
+ * @group auth
+ * @group fortify
+ * @group failed-password-reset-link-api-response
+ *
+ * @author Alin Eugen Deac <ade@rspsystems.com>
+ * @package Aedart\Tests\Integration\Auth\Fortify
+ */
+class FailedPasswordResetLinkApiResponseTest extends FortifyTestCase
+{
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function throwsPasswordResetLinkFailureWhenRequestIsJson(): void
+    {
+        $this->expectException(PasswordResetLinkFailure::class);
+
+        $request = Request::create(
+            uri: 'https://acme.com/api/v1/password-reset',
+            method: 'POST',
+            server:  [
+                'HTTP_ACCEPT' => 'application/json'
+            ],
+        );
+
+        (new FailedPasswordResetLinkApiResponse(PasswordBroker::INVALID_USER))
+            ->toResponse($request);
+    }
+}

--- a/tests/Integration/Auth/Fortify/FailedPasswordResetLinkApiResponseTest.php
+++ b/tests/Integration/Auth/Fortify/FailedPasswordResetLinkApiResponseTest.php
@@ -32,7 +32,7 @@ class FailedPasswordResetLinkApiResponseTest extends FortifyTestCase
         $request = Request::create(
             uri: 'https://acme.com/api/v1/password-reset',
             method: 'POST',
-            server:  [
+            server: [
                 'HTTP_ACCEPT' => 'application/json'
             ],
         );


### PR DESCRIPTION
PR added a few components in the auth package, to ensure that it does not remain entirely empty.

## Details

The following components are added (_extracted from an application_):

* `FailedLoginAttempt` validation exception.
* `PasswordResetLinkFailure` validation exception.
* `FailedPasswordResetLinkApiResponse` - custom implementation of Laravel Fortify's `FailedPasswordResetLinkRequestResponse`.

## References

#202 
