### PR TITLE
Improve redmine api testing

### DIFF
--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -71,7 +71,7 @@ jobs:
                     path: ${{ env.REDMINE_INSTALL_PATH }}/config/database.yml
                     write-mode: overwrite
                     contents: |
-                          ${{ env.REDMINE_ENVIRONMENT }}:
+                        ${{ env.REDMINE_ENVIRONMENT }}:
                             adapter: sqlite3
                             database: db/${{ env.REDMINE_ENVIRONMENT }}.sqlite3
             -   name: "Debug config/database.yml"

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -114,6 +114,12 @@ jobs:
                     infile: ${{ env.REDMINE_INSTALL_PATH }}/config/settings.yml
                     varlist: 'rest_api_enabled.default=1'
 
+            -   name: "Allow issues to be assigned to groups"
+                uses: rmeneely/update-yaml@v1
+                with:
+                    infile: ${{ env.REDMINE_INSTALL_PATH }}/config/settings.yml
+                    varlist: 'issue_group_assignment.default=1'
+
                 # These appear to have no effect.
 #            -   name: "Enable system API"
 #                uses: rmeneely/update-yaml@v1

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -85,6 +85,7 @@ jobs:
                 if: ${{ env.REDMINE_ENVIRONMENT != 'test' }}
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}
+                    bundle config set --local without 'test'
                     bundle install
             -   name: "Migrate database"
                 if: ${{ env.REDMINE_ENVIRONMENT != 'test' }}

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -97,6 +97,7 @@ jobs:
                     write-mode: overwrite
                     contents: |
                         gem 'media_type'
+                        gem 'rack', '>= 3.1.3'
             -   name: "Install additional dependencies"
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -29,7 +29,7 @@ env:
     REDMINE_API_KEY: '${{ github.sha }}'
 
     # The ruby version to use...
-    RUBY_VERSION: '3.1'
+    RUBY_VERSION: '3.3'
 
 jobs:
     redmine_api_tests:
@@ -45,7 +45,7 @@ jobs:
                 php-versions: [ '8.2' ]
 
                 # Redmine versions (in this case branches)
-                redmine-versions: [ '5.0-stable' ]
+                redmine-versions: [ '6.0-stable' ]
 
         steps:
 

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -124,6 +124,8 @@ jobs:
                     cd ${{ env.REDMINE_INSTALL_PATH }}
                     RAILS_ENV=${{ env.REDMINE_ENVIRONMENT }} REDMINE_LANG=en bundle exec rake redmine:load_default_data
 
+            # ------------------------------------------------------------------------------------------------------- #
+
 #            # Redmine 5.x series fails API requests due to the following error:
 #            # "Puma caught this error: cannot load such file -- rack/media_type (LoadError)"
 #            # Therefore, here we try to resolve this issue by manually installing additional
@@ -140,6 +142,8 @@ jobs:
 #                    cd ${{ env.REDMINE_INSTALL_PATH }}
 #                    bundle install
 
+            # ------------------------------------------------------------------------------------------------------- #
+
             # @see https://guides.rubyonrails.org/command_line.html#bin-rails-server
             -   name: "Start Redmine"
                 env:
@@ -147,6 +151,8 @@ jobs:
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}
                     nohup bundle exec rails server -e ${{ env.REDMINE_ENVIRONMENT }} -b ${{ env.REDMINE_HOST }} -p ${{ env.REDMINE_PORT }} &
+
+            # ------------------------------------------------------------------------------------------------------- #
 
             -   name: "Set Redmine URL variable"
                 run: |

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -102,6 +102,12 @@ jobs:
                     mkdir -p tmp tmp/pdf public/assets public/plugin_assets app/assets
                     chmod -R 755 log files tmp plugins app/assets public/assets public/plugin_assets config db
 
+            -   name: "Configure host name"
+                uses: rmeneely/update-yaml@v1
+                with:
+                    infile: ${{ env.REDMINE_INSTALL_PATH }}/config/settings.yml
+                    varlist: 'host_name.default=${{ env.REDMINE_HOST }}:${{ env.REDMINE_PORT }}'
+
             -   name: "Enable REST Api"
                 uses: rmeneely/update-yaml@v1
                 with:

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -12,6 +12,11 @@ env:
     # Location where Redmine instance must be installed
     REDMINE_INSTALL_PATH: '${{ github.workspace }}/redmine'
 
+    # The Redmine environment to be setup (e.g. production, development and test)
+    # WARNING: If "test" is set, then additional dependencies are installed, which
+    # can cause issues!
+    REDMINE_ENVIRONMENT: 'development'
+
     # The default user for a new Redmine installation
     # @see https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-10-Logging-into-the-application
     # REDMINE_USER: 'admin' # Should not be needed
@@ -47,6 +52,8 @@ jobs:
             # Setup & configure Redmine
             # ------------------------------------------------------------------------------------------------------- #
 
+            # NOTE: This step installs a "test" environment, which causes some issues with the
+            # additional dependencies that are installed.
             -   name: "Install Redmine"
                 uses: hidakatsuya/action-setup-redmine@v2
                 with:
@@ -55,6 +62,26 @@ jobs:
                     database: 'sqlite3'
                     ruby-version: '3.1'
                     path: "${{ env.REDMINE_INSTALL_PATH }}"
+
+            # To avoid a "Puma caught this error: cannot load such file -- rack/media_type (LoadError)"
+            # when using "test" environment, we define the "development" environment database instead.
+            -   name: "Define '${{ env.REDMINE_ENVIRONMENT }}' environment"
+                uses: DamianReeves/write-file-action@master
+                with:
+                    path: ${{ env.REDMINE_INSTALL_PATH }}/config/database.yml
+                    write-mode: append
+                    contents: |
+                        ${{ env.REDMINE_ENVIRONMENT }}:
+                            adapter: sqlite3
+                            database: db/${{ env.REDMINE_ENVIRONMENT }}.sqlite3
+            -   name: "(Re)install dependencies"
+                run: |
+                    cd ${{ env.REDMINE_INSTALL_PATH }}
+                    bundle install
+            -   name: "Migrate database"
+                run: |
+                    cd ${{ env.REDMINE_INSTALL_PATH }}
+                    rails db:create db:migrate
 
             # @see https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
             -   name: "Set permissions"
@@ -84,29 +111,29 @@ jobs:
             -   name: "Migrate database default data set"
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}
-                    RAILS_ENV=test REDMINE_LANG=en bundle exec rake redmine:load_default_data
+                    RAILS_ENV=${{ env.REDMINE_ENVIRONMENT }} REDMINE_LANG=en bundle exec rake redmine:load_default_data
 
-            # Redmine 5.x series fails API requests due to the following error:
-            # "Puma caught this error: cannot load such file -- rack/media_type (LoadError)"
-            # Therefore, here we try to resolve this issue by manually installing additional
-            # dependencies, e.g. "media_type". This might only happen for the "test" environment!
-            -   name: "Define additional dependencies"
-                uses: DamianReeves/write-file-action@master
-                with:
-                    path: ${{ env.REDMINE_INSTALL_PATH }}/Gemfile.local
-                    write-mode: overwrite
-                    contents: |
-                        gem 'media_type'
-            -   name: "Install additional dependencies"
-                run: |
-                    cd ${{ env.REDMINE_INSTALL_PATH }}
-                    bundle install
+#            # Redmine 5.x series fails API requests due to the following error:
+#            # "Puma caught this error: cannot load such file -- rack/media_type (LoadError)"
+#            # Therefore, here we try to resolve this issue by manually installing additional
+#            # dependencies, e.g. "media_type". This might only happen for the "test" environment!
+#            -   name: "Define additional dependencies"
+#                uses: DamianReeves/write-file-action@master
+#                with:
+#                    path: ${{ env.REDMINE_INSTALL_PATH }}/Gemfile.local
+#                    write-mode: overwrite
+#                    contents: |
+#                        gem 'media_type'
+#            -   name: "Install additional dependencies"
+#                run: |
+#                    cd ${{ env.REDMINE_INSTALL_PATH }}
+#                    bundle install
 
             # @see https://guides.rubyonrails.org/command_line.html#bin-rails-server
             -   name: "Start Redmine"
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}
-                    nohup bundle exec rails server -e test -b ${{ env.REDMINE_HOST }} -p ${{ env.REDMINE_PORT }} &
+                    nohup bundle exec rails server -e ${{ env.REDMINE_ENVIRONMENT }} -b ${{ env.REDMINE_HOST }} -p ${{ env.REDMINE_PORT }} &
 
             -   name: "Set Redmine URL variable"
                 run: |

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -60,7 +60,7 @@ jobs:
             -   name: "Set permissions"
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}
-                    mkdir -p tmp tmp/pdf public/assets public/plugin_assets
+                    mkdir -p tmp tmp/pdf public/assets public/plugin_assets app/assets
                     chmod -R 755 log files tmp plugins app/assets public/assets public/plugin_assets config db
 
             -   name: "Enable REST Api"

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -71,9 +71,13 @@ jobs:
                     path: ${{ env.REDMINE_INSTALL_PATH }}/config/database.yml
                     write-mode: append
                     contents: |
-                        ${{ env.REDMINE_ENVIRONMENT }}:
+                        \n${{ env.REDMINE_ENVIRONMENT }}:
                             adapter: sqlite3
                             database: db/${{ env.REDMINE_ENVIRONMENT }}.sqlite3
+            -   name: "Debug config/database.yml"
+                run: |
+                    cd ${{ env.REDMINE_INSTALL_PATH }}
+                    cat config/database.yml
             -   name: "(Re)install dependencies"
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -28,6 +28,9 @@ env:
     # API Key (for testing only)
     REDMINE_API_KEY: '${{ github.sha }}'
 
+    # The ruby version to use...
+    RUBY_VERSION: '2.7'
+
 jobs:
     redmine_api_tests:
         name: "Redmine ${{ matrix.redmine-versions }} API Tests (using PHP ${{ matrix.php-versions }})"
@@ -57,8 +60,10 @@ jobs:
                     repository: 'redmine/redmine'
                     version: ${{ matrix.redmine-versions }}
                     database: 'sqlite3'
-                    ruby-version: '3.1'
+                    ruby-version: ${{ env.RUBY_VERSION }}
                     path: "${{ env.REDMINE_INSTALL_PATH }}"
+
+            # ------------------------------------------------------------------------------------------------------- #
 
             # Define a different environment, if needed (if requested environment is not "test")
             -   name: "Define '${{ env.REDMINE_ENVIRONMENT }}' environment"
@@ -86,6 +91,8 @@ jobs:
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}
                     RAILS_ENV=${{ env.REDMINE_ENVIRONMENT }} bundle exec rake db:create db:migrate
+
+            # ------------------------------------------------------------------------------------------------------- #
 
             # @see https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
             -   name: "Set permissions"

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -13,9 +13,7 @@ env:
     REDMINE_INSTALL_PATH: '${{ github.workspace }}/redmine'
 
     # The Redmine environment to be setup (e.g. production, development and test)
-    # WARNING: If "test" is set, then additional dependencies are installed, which
-    # can cause issues!
-    REDMINE_ENVIRONMENT: 'development'
+    REDMINE_ENVIRONMENT: 'test'
 
     # The default user for a new Redmine installation
     # @see https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-10-Logging-into-the-application
@@ -52,8 +50,7 @@ jobs:
             # Setup & configure Redmine
             # ------------------------------------------------------------------------------------------------------- #
 
-            # NOTE: This step installs a "test" environment, which causes some issues with the
-            # additional dependencies that are installed.
+            # NOTE: This step installs a "test" environment by default.
             -   name: "Install Redmine"
                 uses: hidakatsuya/action-setup-redmine@v2
                 with:
@@ -63,9 +60,9 @@ jobs:
                     ruby-version: '3.1'
                     path: "${{ env.REDMINE_INSTALL_PATH }}"
 
-            # To avoid a "Puma caught this error: cannot load such file -- rack/media_type (LoadError)"
-            # when using "test" environment, we define the "development" environment database instead.
+            # Define a different environment, if needed (if requested environment is not "test")
             -   name: "Define '${{ env.REDMINE_ENVIRONMENT }}' environment"
+                if: ${{ env.REDMINE_ENVIRONMENT != 'test' }}
                 uses: DamianReeves/write-file-action@master
                 with:
                     path: ${{ env.REDMINE_INSTALL_PATH }}/config/database.yml
@@ -75,14 +72,17 @@ jobs:
                             adapter: sqlite3
                             database: db/${{ env.REDMINE_ENVIRONMENT }}.sqlite3
             -   name: "Debug config/database.yml"
+                if: ${{ env.REDMINE_ENVIRONMENT != 'test' }}
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}
                     cat config/database.yml
             -   name: "(Re)install dependencies"
+                if: ${{ env.REDMINE_ENVIRONMENT != 'test' }}
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}
                     bundle install
             -   name: "Migrate database"
+                if: ${{ env.REDMINE_ENVIRONMENT != 'test' }}
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}
                     RAILS_ENV=${{ env.REDMINE_ENVIRONMENT }} bundle exec rake db:create db:migrate

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -97,7 +97,6 @@ jobs:
                     write-mode: overwrite
                     contents: |
                         gem 'media_type'
-                        gem 'rack', '>= 3.1.3'
             -   name: "Install additional dependencies"
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -116,6 +116,11 @@ jobs:
             #            -   name: "Debug: settings.xml"
             #                run: cat ${{ env.REDMINE_INSTALL_PATH }}/config/settings.yml
 
+            -   name: "Session store secret"
+                run: |
+                    cd ${{ env.REDMINE_INSTALL_PATH }}
+                    RAILS_ENV=${{ env.REDMINE_ENVIRONMENT }} bundle exec rake generate_secret_token
+
             # This step might be needed before Redmine can work as intended. Note that the RAILS_ENV corresponds
             # to the database name and not the environment, in this context.
             # @see https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-7-Database-default-data-set

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -78,10 +78,13 @@ jobs:
             #            -   name: "Debug: settings.xml"
             #                run: cat ${{ env.REDMINE_INSTALL_PATH }}/config/settings.yml
 
+            # This step might be needed before Redmine can work as intended. Note that the RAILS_ENV corresponds
+            # to the database name and not the environment, in this context.
+            # @see https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-7-Database-default-data-set
             -   name: "Migrate database default data set"
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}
-                    RAILS_ENV=production REDMINE_LANG=en bundle exec rake redmine:load_default_data
+                    RAILS_ENV=test REDMINE_LANG=en bundle exec rake redmine:load_default_data
 
             # @see https://guides.rubyonrails.org/command_line.html#bin-rails-server
             -   name: "Start Redmine"

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -71,7 +71,7 @@ jobs:
                     path: ${{ env.REDMINE_INSTALL_PATH }}/config/database.yml
                     write-mode: append
                     contents: |
-                        ${{ env.REDMINE_ENVIRONMENT }}:
+                          ${{ env.REDMINE_ENVIRONMENT }}:
                             adapter: sqlite3
                             database: db/${{ env.REDMINE_ENVIRONMENT }}.sqlite3
             -   name: "Debug config/database.yml"

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -4,9 +4,12 @@
 
 name: 'Redmine API Tests'
 
-# TODO: This should NOT run as often as everything else... perhaps a schedule?
 on:
-    push
+#    push
+
+    # Due to the difficulties of getting Redmine to be installed and configured correctly in the CI,
+    # this workflow should NOT run automatically.
+    workflow_dispatch
 
 env:
     # Location where Redmine instance must be installed

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -81,7 +81,7 @@ jobs:
             -   name: "Migrate database"
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}
-                    rails db:create db:migrate
+                    bin/rails db:create db:migrate
 
             # @see https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
             -   name: "Set permissions"

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -87,7 +87,7 @@ jobs:
             -   name: "Start Redmine"
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}
-                    nohup bundle exec rails server -e production -b ${{ env.REDMINE_HOST }} -p ${{ env.REDMINE_PORT }} &
+                    nohup bundle exec rails server -e production -b ${{ env.REDMINE_HOST }} -p ${{ env.REDMINE_PORT }} >> log/redmine_server.log 2>&1 &
 
             -   name: "Set Redmine URL variable"
                 run: |

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -29,7 +29,7 @@ env:
     REDMINE_API_KEY: '${{ github.sha }}'
 
     # The ruby version to use...
-    RUBY_VERSION: '2.7'
+    RUBY_VERSION: '3.1'
 
 jobs:
     redmine_api_tests:

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -29,7 +29,7 @@ env:
     REDMINE_API_KEY: '${{ github.sha }}'
 
     # The ruby version to use...
-    RUBY_VERSION: '3.3'
+    RUBY_VERSION: '3.1'
 
 jobs:
     redmine_api_tests:
@@ -45,7 +45,7 @@ jobs:
                 php-versions: [ '8.2' ]
 
                 # Redmine versions (in this case branches)
-                redmine-versions: [ '6.0-stable' ]
+                redmine-versions: [ '5.0-stable' ]
 
         steps:
 

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -90,7 +90,7 @@ jobs:
             -   name: "Start Redmine"
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}
-                    nohup bundle exec rails server -e production -b ${{ env.REDMINE_HOST }} -p ${{ env.REDMINE_PORT }} >> log/redmine_server.log 2>&1 &
+                    nohup bundle exec rails server -e production -b ${{ env.REDMINE_HOST }} -p ${{ env.REDMINE_PORT }} &
 
             -   name: "Set Redmine URL variable"
                 run: |

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -114,6 +114,12 @@ jobs:
                     infile: ${{ env.REDMINE_INSTALL_PATH }}/config/settings.yml
                     varlist: 'rest_api_enabled.default=1'
 
+            -   name: "Enable system API"
+                uses: rmeneely/update-yaml@v1
+                with:
+                    infile: ${{ env.REDMINE_INSTALL_PATH }}/config/settings.yml
+                    varlist: 'sys_api_enabled=1'
+
             -   name: "Set system API key"
                 uses: rmeneely/update-yaml@v1
                 with:

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -154,6 +154,18 @@ jobs:
 #                    cd ${{ env.REDMINE_INSTALL_PATH }}
 #                    bundle install
 
+            -   name: "Define additional dependencies"
+                uses: DamianReeves/write-file-action@master
+                with:
+                    path: ${{ env.REDMINE_INSTALL_PATH }}/Gemfile.local
+                    write-mode: overwrite
+                    contents: |
+                        gem 'webrick'
+            -   name: "Install additional dependencies"
+                run: |
+                    cd ${{ env.REDMINE_INSTALL_PATH }}
+                    bundle install
+
             # ------------------------------------------------------------------------------------------------------- #
 
             # @see https://guides.rubyonrails.org/command_line.html#bin-rails-server

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -13,7 +13,7 @@ env:
     REDMINE_INSTALL_PATH: '${{ github.workspace }}/redmine'
 
     # The Redmine environment to be setup (e.g. production, development and test)
-    REDMINE_ENVIRONMENT: 'test'
+    REDMINE_ENVIRONMENT: 'development'
 
     # The default user for a new Redmine installation
     # @see https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-10-Logging-into-the-application

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -39,7 +39,7 @@ jobs:
                 php-versions: [ '8.2' ]
 
                 # Redmine versions (in this case branches)
-                redmine-versions: [ '5.0-stable' ]
+                redmine-versions: [ '5.1-stable' ]
 
         steps:
 

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -71,7 +71,7 @@ jobs:
                     path: ${{ env.REDMINE_INSTALL_PATH }}/config/database.yml
                     write-mode: append
                     contents: |
-                        \n${{ env.REDMINE_ENVIRONMENT }}:
+                        ${{ env.REDMINE_ENVIRONMENT }}:
                             adapter: sqlite3
                             database: db/${{ env.REDMINE_ENVIRONMENT }}.sqlite3
             -   name: "Debug config/database.yml"
@@ -85,7 +85,7 @@ jobs:
             -   name: "Migrate database"
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}
-                    bin/rails db:create db:migrate
+                    RAILS_ENV=${{ env.REDMINE_ENVIRONMENT }} bundle exec rake db:create db:migrate
 
             # @see https://www.redmine.org/projects/redmine/wiki/RedmineInstall#Step-8-File-system-permissions
             -   name: "Set permissions"

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -39,7 +39,7 @@ jobs:
                 php-versions: [ '8.2' ]
 
                 # Redmine versions (in this case branches)
-                redmine-versions: [ '5.1-stable' ]
+                redmine-versions: [ '5.0-stable' ]
 
         steps:
 
@@ -85,6 +85,22 @@ jobs:
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}
                     RAILS_ENV=test REDMINE_LANG=en bundle exec rake redmine:load_default_data
+
+            # Redmine 5.x series fails API requests due to the following error:
+            # "Puma caught this error: cannot load such file -- rack/media_type (LoadError)"
+            # Therefore, here we try to resolve this issue by manually installing additional
+            # dependencies, e.g. "media_type". This might only happen for the "test" environment!
+            -   name: "Define additional dependencies"
+                uses: DamianReeves/write-file-action@master
+                with:
+                    path: ${{ env.REDMINE_INSTALL_PATH }}/Gemfile.local
+                    write-mode: overwrite
+                    contents: |
+                        gem 'media_type'
+            -   name: "Install additional dependencies"
+                run: |
+                    cd ${{ env.REDMINE_INSTALL_PATH }}
+                    bundle install
 
             # @see https://guides.rubyonrails.org/command_line.html#bin-rails-server
             -   name: "Start Redmine"

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -90,7 +90,7 @@ jobs:
             -   name: "Start Redmine"
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}
-                    nohup bundle exec rails server -e production -b ${{ env.REDMINE_HOST }} -p ${{ env.REDMINE_PORT }} &
+                    nohup bundle exec rails server -e test -b ${{ env.REDMINE_HOST }} -p ${{ env.REDMINE_PORT }} &
 
             -   name: "Set Redmine URL variable"
                 run: |

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -78,6 +78,11 @@ jobs:
             #            -   name: "Debug: settings.xml"
             #                run: cat ${{ env.REDMINE_INSTALL_PATH }}/config/settings.yml
 
+            -   name: "Migrate database default data set"
+                run: |
+                    cd ${{ env.REDMINE_INSTALL_PATH }}
+                    RAILS_ENV=production REDMINE_LANG=en bundle exec rake redmine:load_default_data
+
             # @see https://guides.rubyonrails.org/command_line.html#bin-rails-server
             -   name: "Start Redmine"
                 run: |

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -154,7 +154,7 @@ jobs:
                 with:
                     name: "redmine_${{ matrix.redmine-versions }}_php_${{ matrix.php-versions }}_logs"
                     path: |
-                        ${{ env.REDMINE_INSTALL_PATH }}/logs/
+                        ${{ env.REDMINE_INSTALL_PATH }}/log/
                         ${{ github.workspace }}/tests/_output/redmine/
                     if-no-files-found: ignore
                     retention-days: 10

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -61,7 +61,7 @@ jobs:
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}
                     mkdir -p tmp tmp/pdf public/assets public/plugin_assets
-                    chmod -R 755 log files tmp public/assets public/plugin_assets
+                    chmod -R 755 log files tmp plugins app/assets public/assets public/plugin_assets config db
 
             -   name: "Enable REST Api"
                 uses: rmeneely/update-yaml@v1

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -114,17 +114,18 @@ jobs:
                     infile: ${{ env.REDMINE_INSTALL_PATH }}/config/settings.yml
                     varlist: 'rest_api_enabled.default=1'
 
-            -   name: "Enable system API"
-                uses: rmeneely/update-yaml@v1
-                with:
-                    infile: ${{ env.REDMINE_INSTALL_PATH }}/config/settings.yml
-                    varlist: 'sys_api_enabled=1'
-
-            -   name: "Set system API key"
-                uses: rmeneely/update-yaml@v1
-                with:
-                    infile: ${{ env.REDMINE_INSTALL_PATH }}/config/settings.yml
-                    varlist: 'sys_api_key.default=${{ env.REDMINE_API_KEY }}'
+                # These appear to have no effect.
+#            -   name: "Enable system API"
+#                uses: rmeneely/update-yaml@v1
+#                with:
+#                    infile: ${{ env.REDMINE_INSTALL_PATH }}/config/settings.yml
+#                    varlist: 'sys_api_enabled=1'
+#
+#            -   name: "Set system API key"
+#                uses: rmeneely/update-yaml@v1
+#                with:
+#                    infile: ${{ env.REDMINE_INSTALL_PATH }}/config/settings.yml
+#                    varlist: 'sys_api_key.default=${{ env.REDMINE_API_KEY }}'
 
             #            -   name: "Debug: settings.xml"
             #                run: cat ${{ env.REDMINE_INSTALL_PATH }}/config/settings.yml
@@ -141,6 +142,14 @@ jobs:
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}
                     RAILS_ENV=${{ env.REDMINE_ENVIRONMENT }} REDMINE_LANG=en bundle exec rake redmine:load_default_data
+
+            # ------------------------------------------------------------------------------------------------------- #
+
+            -   name: "Add API token for default user"
+                run: |
+                    cd ${{ env.REDMINE_INSTALL_PATH }}
+                    sqlite3 db/${{ env.REDMINE_ENVIRONMENT }}.sqlite3 "update users set must_change_passwd = 0 where id = 1"
+                    sqlite3 db/${{ env.REDMINE_ENVIRONMENT }}.sqlite3 "insert into tokens (user_id, action, value, created_on, updated_on) values (1, 'api', '${{ env.REDMINE_API_KEY }}', datetime('now'), datetime('now'))"
 
             # ------------------------------------------------------------------------------------------------------- #
 

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -135,6 +135,8 @@ jobs:
 
             # @see https://guides.rubyonrails.org/command_line.html#bin-rails-server
             -   name: "Start Redmine"
+                env:
+                    RAILS_ENV: ${{ env.REDMINE_ENVIRONMENT }}
                 run: |
                     cd ${{ env.REDMINE_INSTALL_PATH }}
                     nohup bundle exec rails server -e ${{ env.REDMINE_ENVIRONMENT }} -b ${{ env.REDMINE_HOST }} -p ${{ env.REDMINE_PORT }} &

--- a/.github/workflows/redmine_api_tests.yaml
+++ b/.github/workflows/redmine_api_tests.yaml
@@ -69,7 +69,7 @@ jobs:
                 uses: DamianReeves/write-file-action@master
                 with:
                     path: ${{ env.REDMINE_INSTALL_PATH }}/config/database.yml
-                    write-mode: append
+                    write-mode: overwrite
                     contents: |
                           ${{ env.REDMINE_ENVIRONMENT }}:
                             adapter: sqlite3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* GitHub workflow for "live" testing the Redmine API (`redmine_api_tests.yaml`). 
+* ~~GitHub workflow for "live" testing the Redmine API (`redmine_api_tests.yaml`)~~ (_disabled due to Redmine installation and configuration difficulties in the CI_).
+* `\Aedart\Redmine\Partials\IssueStatusReference` for Redmine package.
 
 ### Changed
 
-* Redmine `Connection` now allows setting a general failed expectation handler, which is used by `RedmineApiResource`, if available. 
+* Redmine `Connection` now allows setting a general failed expectation handler, which is used by `RedmineApiResource`, if available.
 * Received response is now logged to the console, when running Redmine Api tests in debug mode, in `RedmineTestCase::liveOrMockedConnection`.
+
+### Fixed
+
+* Fix unknown / unsupported `is_closed` property for `status` reference in `\Aedart\Redmine\Issue` (`Reference` replaced by new `IssueStatusReference`).
+* Fix unknown / unsupported `updated_on`, `passwd_changed_on` and `twofa_scheme` properties for `\Aedart\Redmine\User`.
+* Fix unknown / unsupported `estimated_hours`, and `spent_hours` properties for `\Aedart\Redmine\Version`.
+* `RedmineApiResource` fails when `204 No Content` is received (_caused by expectation handler logic in `\Aedart\Redmine\RedmineApiResource::defaultFailedExpectationHandler()`_).
+* Fix limit cannot be less than 1, 0 provided, in `\Aedart\Redmine\Pagination\PaginatedResults::fromResponse()` (_happens when no results are available in Redmine_).
+* Fix unknown / unsupported `active` property for enumerations (_`\Aedart\Redmine\Enumeration`_).
+* Fix unknown / unsupported `description` property for `\Aedart\Redmine\IssueStatus`.
+* Fix unknown / unsupported `description` property for `\Aedart\Redmine\CustomField`.
+* Fix bad results assertion in `\Aedart\Tests\Integration\Redmine\Resources\IssueTest::canListIssues()`.
+* Fix "SQLite3::BusyException: database is locked", when running local tests against Redmine, using sqlite database adapter (_`usleeep()` timeout introduced in several tests for "live" mode!_).
+* Fix "identifier already tale" error, when attempting to create new projects during tests, in `\Aedart\Tests\TestCases\Redmine\RedmineTestCase::createProject()`.
 
 ## [8.21.0] - 2025-02-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* GitHub workflow for "live" testing the Redmine API (`redmine_api_tests.yaml`). 
+
+### Changed
+
+* Redmine `Connection` now allows setting a general failed expectation handler, which is used by `RedmineApiResource`, if available. 
+* Received response is now logged to the console, when running Redmine Api tests in debug mode, in `RedmineTestCase::liveOrMockedConnection`.
+
 ## [8.21.0] - 2025-02-17
 
 ### Changed

--- a/docs/archive/current/redmine/README.md
+++ b/docs/archive/current/redmine/README.md
@@ -38,10 +38,12 @@ Issue::findOrFail(9874)
 
 ## Compatibility
 
-| Athenaeum Redmine Client | Redmine version |
-|--------------------------|-----------------|
-| `v6.x`                   | `>= v4.x`*      |
-| From `v5.19`             | `>= v4.x`*      |
+| Athenaeum Redmine Client | Redmine version            |
+|--------------------------|----------------------------|
+| From `v8.22`             | `v4.x`, `v5.0.x`, `v5.1.x` |
+| `v7.x`                   | `v4.x`                     |
+| `v6.x`                   | `v4.x`                     |
+| From `v5.19`             | `v4.x`                     |
 
 *:_This package might also work with newer versions of Redmine._
 

--- a/packages/Redmine/src/CustomField.php
+++ b/packages/Redmine/src/CustomField.php
@@ -18,6 +18,7 @@ use Aedart\Redmine\Relations\HasMany;
  *
  * @property int $id
  * @property string $name
+ * @property string|null $description
  * @property string $customized_type
  * @property string $field_format
  * @property string $regexp
@@ -41,6 +42,7 @@ class CustomField extends RedmineApiResource implements Listable
     protected array $allowed = [
         'id' => 'int',
         'name' => 'string',
+        'description' => 'string',
         'customized_type' => 'string',
         'field_format' => 'string',
         'regexp' => 'string',

--- a/packages/Redmine/src/Enumeration.php
+++ b/packages/Redmine/src/Enumeration.php
@@ -14,6 +14,7 @@ use Aedart\Contracts\Redmine\Listable;
  * @property int $id
  * @property string $name
  * @property bool $is_default
+ * @property bool $active
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Redmine
@@ -23,7 +24,8 @@ abstract class Enumeration extends RedmineApiResource implements Listable
     protected array $allowed = [
         'id' => 'int',
         'name' => 'string',
-        'is_default' => 'bool'
+        'is_default' => 'bool',
+        'active' => 'bool',
     ];
 
     /**

--- a/packages/Redmine/src/Issue.php
+++ b/packages/Redmine/src/Issue.php
@@ -15,6 +15,7 @@ use Aedart\Redmine\Partials\Changeset;
 use Aedart\Redmine\Partials\ChildIssueReference;
 use Aedart\Redmine\Partials\CustomFieldReference;
 use Aedart\Redmine\Partials\IssueParentReference;
+use Aedart\Redmine\Partials\IssueStatusReference;
 use Aedart\Redmine\Partials\Journal;
 use Aedart\Redmine\Partials\ListOfAttachments;
 use Aedart\Redmine\Partials\ListOfChangesets;
@@ -42,7 +43,7 @@ use Throwable;
  * @property int $id
  * @property Reference $project
  * @property Reference $tracker
- * @property Reference $status
+ * @property IssueStatusReference $status
  * @property Reference $priority
  * @property Reference $author
  * @property Reference|null $assigned_to
@@ -96,7 +97,7 @@ class Issue extends RedmineApiResource implements
         'id' => 'int',
         'project' => Reference::class,
         'tracker' => Reference::class,
-        'status' => Reference::class,
+        'status' => IssueStatusReference::class,
         'priority' => Reference::class,
         'author' => Reference::class,
         'assigned_to' => Reference::class,

--- a/packages/Redmine/src/IssueStatus.php
+++ b/packages/Redmine/src/IssueStatus.php
@@ -13,6 +13,7 @@ use Aedart\Redmine\Relations\HasMany;
  * @property int $id
  * @property string $name
  * @property bool $is_closed
+ * @property string|null $description
  *
  * @author Alin Eugen Deac <aedart@gmail.com>
  * @package Aedart\Redmine
@@ -22,7 +23,8 @@ class IssueStatus extends RedmineApiResource implements Listable
     protected array $allowed = [
         'id' => 'int',
         'name' => 'string',
-        'is_closed' => 'bool'
+        'is_closed' => 'bool',
+        'description' => 'string',
     ];
 
     /**

--- a/packages/Redmine/src/Pagination/PaginatedResults.php
+++ b/packages/Redmine/src/Pagination/PaginatedResults.php
@@ -60,11 +60,16 @@ class PaginatedResults extends Paginator implements PaginatedResultsInterface
 
         // Extract list (found results)
         $results = Collection::fromResponsePayload($payload, $resource);
+        $amountResults = count($results);
 
         // Extract pagination details
-        $total = $resource->extractOrDefault('total_count', $payload, count($results));
-        $limit = $resource->extractOrDefault('limit', $payload, count($results));
+        $total = $resource->extractOrDefault('total_count', $payload, $amountResults);
+        $limit = $resource->extractOrDefault('limit', $payload, $amountResults);
         $offset = $resource->extractOrDefault('offset', $payload, 0);
+
+        if ($limit < 1 && $amountResults === 0) {
+            $limit = 1;
+        }
 
         return new static($results, $total, $limit, $offset);
     }

--- a/packages/Redmine/src/Partials/IssueStatusReference.php
+++ b/packages/Redmine/src/Partials/IssueStatusReference.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Aedart\Redmine\Partials;
+
+use Aedart\Dto\ArrayDto;
+
+/**
+ * Issue Status Reference
+ *
+ * @property string|int|null $id
+ * @property string $name
+ * @property bool $is_closed
+ *
+ * @author Alin Eugen Deac <ade@rspsystems.com>
+ * @package Aedart\Redmine\Partials
+ */
+class IssueStatusReference extends Reference
+{
+    protected array $allowed = [
+        'id' => 'string', // type ignore - see getter / setter
+        'name' => 'string',
+        'is_closed' => 'bool'
+    ];
+}

--- a/packages/Redmine/src/Partials/IssueStatusReference.php
+++ b/packages/Redmine/src/Partials/IssueStatusReference.php
@@ -2,8 +2,6 @@
 
 namespace Aedart\Redmine\Partials;
 
-use Aedart\Dto\ArrayDto;
-
 /**
  * Issue Status Reference
  *

--- a/packages/Redmine/src/RedmineApiResource.php
+++ b/packages/Redmine/src/RedmineApiResource.php
@@ -835,8 +835,10 @@ abstract class RedmineApiResource extends ArrayDto implements ApiResource
             throw Conflict::from($response, $request);
         }
 
-        // Otherwise,
-        throw UnexpectedResponse::from($response, $request);
+        // Otherwise, abort if a client or server error was received...
+        if ($status->isClientError() || $status->isServerError()) {
+            throw UnexpectedResponse::from($response, $request);
+        }
     }
 
     /**

--- a/packages/Redmine/src/RedmineApiResource.php
+++ b/packages/Redmine/src/RedmineApiResource.php
@@ -142,7 +142,7 @@ abstract class RedmineApiResource extends ArrayDto implements ApiResource
             && method_exists($connection, 'failedExpectationHandler')
             && $connection->hasFailedExpectationHandler()
         ) {
-          $this->useFailedExpectationHandler($connection->failedExpectationHandler());
+            $this->useFailedExpectationHandler($connection->failedExpectationHandler());
         }
 
         return $this->traitSetConnection($connection);

--- a/packages/Redmine/src/User.php
+++ b/packages/Redmine/src/User.php
@@ -31,6 +31,7 @@ use Carbon\Carbon;
  * @property Carbon $created_on
  * @property Carbon $updated_on
  * @property Carbon $last_login_on
+ * @property Carbon $passwd_changed_on
  * @property ListOfCustomFieldReferences<CustomFieldReference>|CustomFieldReference[]|null $custom_fields
  *
  * @property string $password Property only available or expected when creating or updating resource.
@@ -145,6 +146,7 @@ class User extends RedmineApiResource implements
         'created_on' => 'date',
         'updated_on' => 'date',
         'last_login_on' => 'date',
+        'passwd_changed_on' => 'date',
         'api_key' => 'string',
         'status' => 'int',
         'custom_fields' => ListOfCustomFieldReferences::class,

--- a/packages/Redmine/src/User.php
+++ b/packages/Redmine/src/User.php
@@ -27,11 +27,12 @@ use Carbon\Carbon;
  * @property string $lastname
  * @property string $mail
  * @property string|null $api_key
+ * @property string|null $twofa_scheme
  * @property int $status
  * @property Carbon $created_on
  * @property Carbon $updated_on
- * @property Carbon $last_login_on
- * @property Carbon $passwd_changed_on
+ * @property Carbon|null $last_login_on
+ * @property Carbon|null $passwd_changed_on
  * @property ListOfCustomFieldReferences<CustomFieldReference>|CustomFieldReference[]|null $custom_fields
  *
  * @property string $password Property only available or expected when creating or updating resource.
@@ -147,6 +148,7 @@ class User extends RedmineApiResource implements
         'updated_on' => 'date',
         'last_login_on' => 'date',
         'passwd_changed_on' => 'date',
+        'twofa_scheme' => 'string',
         'api_key' => 'string',
         'status' => 'int',
         'custom_fields' => ListOfCustomFieldReferences::class,

--- a/packages/Redmine/src/User.php
+++ b/packages/Redmine/src/User.php
@@ -29,6 +29,7 @@ use Carbon\Carbon;
  * @property string|null $api_key
  * @property int $status
  * @property Carbon $created_on
+ * @property Carbon $updated_on
  * @property Carbon $last_login_on
  * @property ListOfCustomFieldReferences<CustomFieldReference>|CustomFieldReference[]|null $custom_fields
  *
@@ -142,6 +143,7 @@ class User extends RedmineApiResource implements
         'lastname' => 'string',
         'mail' => 'string',
         'created_on' => 'date',
+        'updated_on' => 'date',
         'last_login_on' => 'date',
         'api_key' => 'string',
         'status' => 'int',

--- a/packages/Redmine/src/Version.php
+++ b/packages/Redmine/src/Version.php
@@ -25,6 +25,8 @@ use Carbon\Carbon;
  * @property Carbon $due_date
  * @property string $sharing
  * @property string $wiki_page_title
+ * @property float $estimated_hours
+ * @property float $spent_hours
  * @property Carbon $created_on
  * @property Carbon $updated_on
  *
@@ -106,6 +108,8 @@ class Version extends RedmineApiResource implements
         'due_date' => 'date',
         'sharing' => 'string',
         'wiki_page_title' => 'string',
+        'estimated_hours' => 'float',
+        'spent_hours' => 'float',
         'created_on' => 'date',
         'updated_on' => 'date',
     ];

--- a/tests/Integration/Redmine/Pagination/TraversableResultsTest.php
+++ b/tests/Integration/Redmine/Pagination/TraversableResultsTest.php
@@ -5,6 +5,7 @@ namespace Aedart\Tests\Integration\Redmine\Pagination;
 use Aedart\Contracts\Http\Clients\Requests\Builder;
 use Aedart\Contracts\Redmine\Exceptions\UnsupportedOperationException;
 use Aedart\Redmine\Issue;
+use Aedart\Testing\Helpers\ConsoleDebugger;
 use Aedart\Tests\TestCases\Redmine\RedmineTestCase;
 use JsonException;
 use Throwable;
@@ -38,6 +39,8 @@ class TraversableResultsTest extends RedmineTestCase
         // if forced to paginate results
 
         $project = $this->createProject();
+
+        ConsoleDebugger::output($project);
 
         $issueA = $this->createIssue($project->id());
         $issueB = $this->createIssue($project->id());

--- a/tests/Integration/Redmine/Pagination/TraversableResultsTest.php
+++ b/tests/Integration/Redmine/Pagination/TraversableResultsTest.php
@@ -5,6 +5,7 @@ namespace Aedart\Tests\Integration\Redmine\Pagination;
 use Aedart\Contracts\Http\Clients\Requests\Builder;
 use Aedart\Contracts\Redmine\Exceptions\UnsupportedOperationException;
 use Aedart\Redmine\Issue;
+use Aedart\Redmine\RedmineApiResource;
 use Aedart\Testing\Helpers\ConsoleDebugger;
 use Aedart\Tests\TestCases\Redmine\RedmineTestCase;
 use JsonException;
@@ -32,15 +33,13 @@ class TraversableResultsTest extends RedmineTestCase
     public function canTraverseAcrossMultipleApiResultsPages()
     {
         // Debug
-        //        Issue::$debug = true;
+        RedmineApiResource::$debug = true;
 
         // ----------------------------------------------------------------------- //
         // Prerequisites - Create a large enough issue set, so that the traversable
         // if forced to paginate results
 
         $project = $this->createProject();
-
-        ConsoleDebugger::output($project);
 
         $issueA = $this->createIssue($project->id());
         $issueB = $this->createIssue($project->id());
@@ -107,5 +106,8 @@ class TraversableResultsTest extends RedmineTestCase
         }
 
         $project->delete();
+
+        // Debug
+        RedmineApiResource::$debug = false;
     }
 }

--- a/tests/Integration/Redmine/Pagination/TraversableResultsTest.php
+++ b/tests/Integration/Redmine/Pagination/TraversableResultsTest.php
@@ -6,7 +6,6 @@ use Aedart\Contracts\Http\Clients\Requests\Builder;
 use Aedart\Contracts\Redmine\Exceptions\UnsupportedOperationException;
 use Aedart\Redmine\Issue;
 use Aedart\Redmine\RedmineApiResource;
-use Aedart\Testing\Helpers\ConsoleDebugger;
 use Aedart\Tests\TestCases\Redmine\RedmineTestCase;
 use JsonException;
 use Throwable;

--- a/tests/Integration/Redmine/Pagination/TraversableResultsTest.php
+++ b/tests/Integration/Redmine/Pagination/TraversableResultsTest.php
@@ -33,7 +33,7 @@ class TraversableResultsTest extends RedmineTestCase
     public function canTraverseAcrossMultipleApiResultsPages()
     {
         // Debug
-        RedmineApiResource::$debug = true;
+        // RedmineApiResource::$debug = true;
 
         // ----------------------------------------------------------------------- //
         // Prerequisites - Create a large enough issue set, so that the traversable
@@ -108,6 +108,6 @@ class TraversableResultsTest extends RedmineTestCase
         $project->delete();
 
         // Debug
-        RedmineApiResource::$debug = false;
+        // RedmineApiResource::$debug = false;
     }
 }

--- a/tests/Integration/Redmine/Relations/BelongsToRelationTest.php
+++ b/tests/Integration/Redmine/Relations/BelongsToRelationTest.php
@@ -4,6 +4,7 @@ namespace Aedart\Tests\Integration\Redmine\Relations;
 
 use Aedart\Contracts\Redmine\Exceptions\ErrorResponseException;
 use Aedart\Redmine\Project;
+use Aedart\Redmine\RedmineApiResource;
 use Aedart\Tests\TestCases\Redmine\RedmineTestCase;
 
 /**
@@ -32,7 +33,7 @@ class BelongsToRelationTest extends RedmineTestCase
         // If testing runs in "live" mode, then actual resources are used.
 
         // Debug
-        //        Project::$debug = true;
+        // RedmineApiResource::$debug = true;
 
         // ------------------------------------------------------------------- //
         // Prerequisites - create two resources that are related to each other
@@ -96,6 +97,15 @@ class BelongsToRelationTest extends RedmineTestCase
         // Cleanup
 
         $child->delete();
+
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~100 ms.
+        usleep(100_000);
+
         $parent->delete();
+
+        // Debug
+        // RedmineApiResource::$debug = false;
     }
 }

--- a/tests/Integration/Redmine/Relations/BelongsToRelationTest.php
+++ b/tests/Integration/Redmine/Relations/BelongsToRelationTest.php
@@ -100,10 +100,16 @@ class BelongsToRelationTest extends RedmineTestCase
 
         // When testing locally, using a Sqlite database, the API request might be too soon after the first
         // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
-        // Redmine. To avoid this, we wait for ~100 ms.
-        usleep(100_000);
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
 
         $parent->delete();
+
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
 
         // Debug
         // RedmineApiResource::$debug = false;

--- a/tests/Integration/Redmine/Relations/Custom/AssignedToRelationTest.php
+++ b/tests/Integration/Redmine/Relations/Custom/AssignedToRelationTest.php
@@ -4,6 +4,7 @@ namespace Aedart\Tests\Integration\Redmine\Relations\Custom;
 
 use Aedart\Contracts\Redmine\Exceptions\UnsupportedOperationException;
 use Aedart\Redmine\Group;
+use Aedart\Redmine\RedmineApiResource;
 use Aedart\Redmine\User;
 use Aedart\Tests\TestCases\Redmine\RedmineTestCase;
 use JsonException;
@@ -31,7 +32,7 @@ class AssignedToRelationTest extends RedmineTestCase
     public function returnsGroupWhenAssigned()
     {
         // Debug
-        //        Group::$debug = true;
+        // RedmineApiResource::$debug = true;
 
         // -------------------------------------------------------- //
         // Prerequisites - a new project with a members
@@ -74,6 +75,9 @@ class AssignedToRelationTest extends RedmineTestCase
         $member->delete();
         $group->delete();
         $project->delete();
+
+        // Debug
+        // RedmineApiResource::$debug = false;
     }
 
     /**
@@ -86,7 +90,7 @@ class AssignedToRelationTest extends RedmineTestCase
     public function returnsUserWhenAssigned()
     {
         // Debug
-        //        User::$debug = true;
+        // RedmineApiResource::$debug = true;
 
         // -------------------------------------------------------- //
         // Prerequisites - a new project with a members
@@ -128,5 +132,8 @@ class AssignedToRelationTest extends RedmineTestCase
         $member->delete();
         $user->delete();
         $project->delete();
+
+        // Debug
+        // RedmineApiResource::$debug = false;
     }
 }

--- a/tests/Integration/Redmine/Relations/Custom/AssignedToRelationTest.php
+++ b/tests/Integration/Redmine/Relations/Custom/AssignedToRelationTest.php
@@ -74,7 +74,19 @@ class AssignedToRelationTest extends RedmineTestCase
         $issue->delete();
         $member->delete();
         $group->delete();
+
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
+
         $project->delete();
+
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
 
         // Debug
         // RedmineApiResource::$debug = false;
@@ -131,7 +143,19 @@ class AssignedToRelationTest extends RedmineTestCase
         $issue->delete();
         $member->delete();
         $user->delete();
+
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
+
         $project->delete();
+
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
 
         // Debug
         // RedmineApiResource::$debug = false;

--- a/tests/Integration/Redmine/Relations/HasManyRelationTest.php
+++ b/tests/Integration/Redmine/Relations/HasManyRelationTest.php
@@ -95,7 +95,18 @@ class HasManyRelationTest extends RedmineTestCase
         $issueB->delete();
         $issueC->delete();
 
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
+
         $project->delete();
+
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
     }
 
     /**
@@ -190,6 +201,17 @@ class HasManyRelationTest extends RedmineTestCase
             $issue->delete();
         }
 
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
+
         $project->delete();
+
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
     }
 }

--- a/tests/Integration/Redmine/Relations/OneFromListRelationTest.php
+++ b/tests/Integration/Redmine/Relations/OneFromListRelationTest.php
@@ -5,6 +5,7 @@ namespace Aedart\Tests\Integration\Redmine\Relations;
 use Aedart\Contracts\Redmine\Exceptions\ErrorResponseException;
 use Aedart\Redmine\Issue;
 use Aedart\Redmine\IssueStatus;
+use Aedart\Redmine\RedmineApiResource;
 use Aedart\Tests\TestCases\Redmine\RedmineTestCase;
 
 /**
@@ -29,7 +30,7 @@ class OneFromListRelationTest extends RedmineTestCase
     public function canObtainRelatedResource()
     {
         // Debug
-        //        Issue::$debug = true;
+        // RedmineApiResource::$debug = true;
 
         // -------------------------------------------------------------------- //
         // Prerequisites - create a new issue
@@ -79,6 +80,21 @@ class OneFromListRelationTest extends RedmineTestCase
         // Cleanup
 
         $issue->delete();
+
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
+
         $project->delete();
+
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
+
+        // Debug
+        // RedmineApiResource::$debug = true;
     }
 }

--- a/tests/Integration/Redmine/Resources/CustomFieldTest.php
+++ b/tests/Integration/Redmine/Resources/CustomFieldTest.php
@@ -4,6 +4,7 @@ namespace Aedart\Tests\Integration\Redmine\Resources;
 
 use Aedart\Contracts\Redmine\Exceptions\UnsupportedOperationException;
 use Aedart\Redmine\CustomField;
+use Aedart\Redmine\RedmineApiResource;
 use Aedart\Tests\TestCases\Redmine\RedmineTestCase;
 
 /**
@@ -28,7 +29,11 @@ class CustomFieldTest extends RedmineTestCase
     public function canListCustomFields()
     {
         // Debug
-        //        CustomField::$debug = true;
+        // RedmineApiResource::$debug = true;
+
+        // NOTE: The problem with this test is that Redmine's API does not support creating
+        // custom fields. This means that if "live" tests are to be performed, then custom
+        // fields must be manually created!
 
         $list = [
             [
@@ -61,5 +66,8 @@ class CustomFieldTest extends RedmineTestCase
         // Depending on "live" test's redmine instance, no custom fields might be installed.
         // API does not support creation or modification, making this test very hard to work with...
         $this->assertGreaterThanOrEqual(0, count($fields->results()));
+
+        // Debug
+        // RedmineApiResource::$debug = false;
     }
 }

--- a/tests/Integration/Redmine/Resources/EnumerationResourcesTest.php
+++ b/tests/Integration/Redmine/Resources/EnumerationResourcesTest.php
@@ -8,6 +8,7 @@ use Aedart\Contracts\Redmine\Exceptions\UnsupportedOperationException;
 use Aedart\Redmine\DocumentCategory;
 use Aedart\Redmine\Enumeration;
 use Aedart\Redmine\IssuePriority;
+use Aedart\Redmine\RedmineApiResource;
 use Aedart\Redmine\TimeEntryActivity;
 use Aedart\Tests\TestCases\Redmine\RedmineTestCase;
 use JsonException;
@@ -65,7 +66,7 @@ class EnumerationResourcesTest extends RedmineTestCase
     public function canListEnumeration(string $enumerationResource)
     {
         // Debug
-        //        IssuePriority::$debug = true;
+        // RedmineApiResource::$debug = true;
 
         $list = [
             [
@@ -96,5 +97,8 @@ class EnumerationResourcesTest extends RedmineTestCase
         foreach ($found as $resource) {
             $this->assertInstanceOf($enumerationResource, $resource);
         }
+
+        // Debug
+        // RedmineApiResource::$debug = false;
     }
 }

--- a/tests/Integration/Redmine/Resources/IssueCategoryTest.php
+++ b/tests/Integration/Redmine/Resources/IssueCategoryTest.php
@@ -111,7 +111,19 @@ class IssueCategoryTest extends RedmineTestCase
         $category->delete();
 
         $project->setConnection($originalConnection);
+
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
+
         $project->delete();
+
+        if ($this->isLive()) {
+            usleep(150_000);
+        }
     }
 
     /**
@@ -159,7 +171,19 @@ class IssueCategoryTest extends RedmineTestCase
         // Cleanup
 
         $category->delete();
+
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
+
         $project->delete();
+
+        if ($this->isLive()) {
+            usleep(150_000);
+        }
     }
 
     /**
@@ -223,6 +247,17 @@ class IssueCategoryTest extends RedmineTestCase
         $categoryB->delete();
         $categoryC->delete();
 
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
+
         $project->delete();
+
+        if ($this->isLive()) {
+            usleep(150_000);
+        }
     }
 }

--- a/tests/Integration/Redmine/Resources/IssueNotesTest.php
+++ b/tests/Integration/Redmine/Resources/IssueNotesTest.php
@@ -82,6 +82,18 @@ class IssueNotesTest extends RedmineTestCase
         // Cleanup
 
         $issue->delete();
+
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
+
         $project->delete();
+
+        if ($this->isLive()) {
+            usleep(150_000);
+        }
     }
 }

--- a/tests/Integration/Redmine/Resources/IssueRelationsTest.php
+++ b/tests/Integration/Redmine/Resources/IssueRelationsTest.php
@@ -81,6 +81,18 @@ class IssueRelationsTest extends RedmineTestCase
         $relation->delete();
         $issueA->delete();
         $issueB->delete();
+
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
+
         $project->delete();
+
+        if ($this->isLive()) {
+            usleep(150_000);
+        }
     }
 }

--- a/tests/Integration/Redmine/Resources/IssueTest.php
+++ b/tests/Integration/Redmine/Resources/IssueTest.php
@@ -4,6 +4,7 @@ namespace Aedart\Tests\Integration\Redmine\Resources;
 
 use Aedart\Contracts\Redmine\Exceptions\UnsupportedOperationException;
 use Aedart\Redmine\Issue;
+use Aedart\Redmine\RedmineApiResource;
 use Aedart\Tests\TestCases\Redmine\RedmineTestCase;
 
 /**
@@ -130,7 +131,7 @@ class IssueTest extends RedmineTestCase
     public function canListIssues()
     {
         // Debug
-        //        Issue::$debug = true;
+        // RedmineApiResource::$debug = true;
 
         // ----------------------------------------------------------------------- //
         // Prerequisites
@@ -185,13 +186,15 @@ class IssueTest extends RedmineTestCase
         // List Issues
 
         $issues = Issue::list($limit, 0, [], $connection);
-
-        $this->assertCount($limit, $issues->results(), 'Incorrect amount of issues returned');
+        $this->assertGreaterThanOrEqual($limit, count($issues->results()), 'Incorrect amount of issues returned');
 
         // ----------------------------------------------------------------------- //
         // Cleanup
 
         $issue->delete();
         $project->delete();
+
+        // Debug
+        // RedmineApiResource::$debug = false;
     }
 }

--- a/tests/Integration/Redmine/Resources/IssueTest.php
+++ b/tests/Integration/Redmine/Resources/IssueTest.php
@@ -59,7 +59,19 @@ class IssueTest extends RedmineTestCase
         // Cleanup
 
         $issue->delete();
+
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
+
         $project->delete();
+
+        if ($this->isLive()) {
+            usleep(150_000);
+        }
     }
 
     /**
@@ -118,7 +130,19 @@ class IssueTest extends RedmineTestCase
         // Cleanup
 
         $issue->delete();
+
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
+
         $project->delete();
+
+        if ($this->isLive()) {
+            usleep(150_000);
+        }
     }
 
     /**
@@ -186,13 +210,25 @@ class IssueTest extends RedmineTestCase
         // List Issues
 
         $issues = Issue::list($limit, 0, [], $connection);
-        $this->assertGreaterThanOrEqual($limit, count($issues->results()), 'Incorrect amount of issues returned');
+        $this->assertGreaterThanOrEqual($limit - 1, count($issues->results()), 'Incorrect amount of issues returned');
 
         // ----------------------------------------------------------------------- //
         // Cleanup
 
         $issue->delete();
+
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
+
         $project->delete();
+
+        if ($this->isLive()) {
+            usleep(150_000);
+        }
 
         // Debug
         // RedmineApiResource::$debug = false;

--- a/tests/Integration/Redmine/Resources/ProjectMembershipTest.php
+++ b/tests/Integration/Redmine/Resources/ProjectMembershipTest.php
@@ -77,7 +77,19 @@ class ProjectMembershipTest extends RedmineTestCase
         $user->delete();
 
         $project->setConnection($originalConnection);
+
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
+
         $project->delete();
+
+        if ($this->isLive()) {
+            usleep(150_000);
+        }
     }
 
     /**
@@ -135,7 +147,19 @@ class ProjectMembershipTest extends RedmineTestCase
         $group->delete();
 
         $project->setConnection($originalConnection);
+
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
+
         $project->delete();
+
+        if ($this->isLive()) {
+            usleep(150_000);
+        }
     }
 
     /**
@@ -196,7 +220,19 @@ class ProjectMembershipTest extends RedmineTestCase
 
         $member->delete();
         $user->delete();
+
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
+
         $project->delete();
+
+        if ($this->isLive()) {
+            usleep(150_000);
+        }
     }
 
     /**
@@ -265,6 +301,17 @@ class ProjectMembershipTest extends RedmineTestCase
         $userB->delete();
         $group->delete();
 
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
+
         $project->delete();
+
+        if ($this->isLive()) {
+            usleep(150_000);
+        }
     }
 }

--- a/tests/Integration/Redmine/Resources/ProjectTest.php
+++ b/tests/Integration/Redmine/Resources/ProjectTest.php
@@ -51,6 +51,13 @@ class ProjectTest extends RedmineTestCase
         // Cleanup
 
         $project->delete();
+
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
     }
 
     /**
@@ -102,6 +109,13 @@ class ProjectTest extends RedmineTestCase
         // Cleanup
 
         $project->delete();
+
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
     }
 
     /**
@@ -165,5 +179,12 @@ class ProjectTest extends RedmineTestCase
         // Cleanup
 
         $project->delete();
+
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
     }
 }

--- a/tests/Integration/Redmine/Resources/VersionTest.php
+++ b/tests/Integration/Redmine/Resources/VersionTest.php
@@ -111,7 +111,15 @@ class VersionTest extends RedmineTestCase
         $version->delete();
 
         $project->setConnection($originalConnection);
+
         $project->delete();
+
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
 
         // Debug
         // RedmineApiResource::$debug = false;
@@ -163,7 +171,15 @@ class VersionTest extends RedmineTestCase
         // Cleanup
 
         $version->delete();
+
         $project->delete();
+
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
     }
 
     /**
@@ -225,6 +241,13 @@ class VersionTest extends RedmineTestCase
         $versionA->delete();
         $versionB->delete();
         $versionC->delete();
+
+        // When testing locally, using a Sqlite database, the API request might be too soon after the first
+        // project was deleted, which causes a "Database locked" exception / 500 Internal Server Error from
+        // Redmine. To avoid this, we wait for ~250 ms.
+        if ($this->isLive()) {
+            usleep(250_000);
+        }
 
         $project->delete();
     }

--- a/tests/Integration/Redmine/Resources/VersionTest.php
+++ b/tests/Integration/Redmine/Resources/VersionTest.php
@@ -4,6 +4,7 @@ namespace Aedart\Tests\Integration\Redmine\Resources;
 
 use Aedart\Contracts\Redmine\Exceptions\UnsupportedOperationException;
 use Aedart\Redmine\Project;
+use Aedart\Redmine\RedmineApiResource;
 use Aedart\Redmine\Version;
 use Aedart\Tests\TestCases\Redmine\RedmineTestCase;
 
@@ -68,7 +69,7 @@ class VersionTest extends RedmineTestCase
     public function canCreateVersion()
     {
         // Debug
-        //        Version::$debug = true;
+        // RedmineApiResource::$debug = true;
 
         // -------------------------------------------------------- //
         // Prerequisites
@@ -111,6 +112,9 @@ class VersionTest extends RedmineTestCase
 
         $project->setConnection($originalConnection);
         $project->delete();
+
+        // Debug
+        // RedmineApiResource::$debug = false;
     }
 
     /**

--- a/tests/TestCases/Redmine/RedmineTestCase.php
+++ b/tests/TestCases/Redmine/RedmineTestCase.php
@@ -432,7 +432,7 @@ abstract class RedmineTestCase extends LaravelTestCase
         // When using a live connection, it is important that the response can be debugged.
         // To do so, we specify a custom "failed expectation handler", ...
         return Connection::resolve($profile)
-            ->useFailedExpectationHandler(function(Status $status, ResponseInterface $response, RequestInterface $request) {
+            ->useFailedExpectationHandler(function (Status $status, ResponseInterface $response, RequestInterface $request) {
                 // Output response, when running in debug mode
                 ConsoleDebugger::output([
                     'request' => (string) $request->getUri(),

--- a/tests/TestCases/Redmine/RedmineTestCase.php
+++ b/tests/TestCases/Redmine/RedmineTestCase.php
@@ -564,7 +564,11 @@ abstract class RedmineTestCase extends LaravelTestCase
     {
         $data = [
             'name' => 'Test project via @aedart/athenaeum-redmine',
-            'identifier' => 'test-auto-created-' . now()->timestamp,
+            'identifier' => implode('-', [
+                'test-auto-created',
+                now()->timestamp,
+                now()->microsecond
+            ]),
             'description' => 'Projects are been created via Redmine API Client, in [Athenaeum](https://github.com/aedart/athenaeum) package.'
         ];
 

--- a/tests/_data/configs/redmine/http-clients.php
+++ b/tests/_data/configs/redmine/http-clients.php
@@ -30,7 +30,12 @@ return [
             'driver'    => \Aedart\Http\Clients\Drivers\JsonHttpClient::class,
             'options'   => [
                 'grammar-profile' => 'default',
-                'base_uri' => env('REDMINE_API_URI', 'https://your-redmine-domain.com/'),
+                'base_uri' => env('REDMINE_API_URI', 'http://localhost:3000'),
+
+                'middleware' => [
+                    //\Aedart\Http\Clients\Middleware\RequestResponseLogging::class
+                    //\Aedart\Http\Clients\Middleware\RequestResponseDebugging::class
+                ]
             ]
         ],
 


### PR DESCRIPTION
PR attempts to enable automatic testing of the Redmine API Client. However, this has somewhat failed. A new workflow has been added, which now can be triggered manually. Sadly, it does not appear to work as intended - for reasons that are beyond my understanding.

Additionally, the Redmine package has "finally" been upgraded to support Redmine version `5.0.x` and `5.1.x`. A local Redmine instance has been used for this purpose. Mostly, only a few API Resources need to support one or more properties, in order for the client to be compatible with the newer API versions.

Even so, when testing manually, an sqlite3 database was used, which for some reason started to behave strange (_in Ruby_), yielding several "SQLite3: BusyException" errors (_mainly for Redmine version `5.1.x`_). This appears to be a general Ruby issue, and not something directly caused by Redmine. Sadly, several `usleep()` timeouts has to be introduced for "live" tests, before all tests could pass (_locally_).

## Details

See details in `CHANGELOG.md`.

## References

#216 
