### PR TITLE
Update docs

### DIFF
--- a/docs/archive/current/README.md
+++ b/docs/archive/current/README.md
@@ -47,6 +47,10 @@ application's environment file.
 
 See [Support package documentation](./support/env-file.md) for details.
 
+### Redmine `v6.0.x` API 
+
+The [Redmine Client](./redmine/README.md) now supports [Redmine `v6.0.x` API](https://www.redmine.org/projects/redmine/wiki/Rest_api). 
+
 ### Auth Exceptions and Responses
 
 The Auth package has received a few new components, intended to be used in combination with for Laravel Fortify.

--- a/docs/archive/current/redmine/README.md
+++ b/docs/archive/current/redmine/README.md
@@ -40,6 +40,7 @@ Issue::findOrFail(9874)
 
 | Athenaeum Redmine Client | Redmine version            |
 |--------------------------|----------------------------|
+| `v9.x`                   | `v6.0.x`                   |
 | From `v8.22`             | `v4.x`, `v5.0.x`, `v5.1.x` |
 | `v7.x`                   | `v4.x`                     |
 | `v6.x`                   | `v4.x`                     |

--- a/docs/archive/current/upgrade-guide.md
+++ b/docs/archive/current/upgrade-guide.md
@@ -19,6 +19,16 @@ You need PHP `v8.3` or higher to run Athenaeum packages.
 
 Please read Laravel's [upgrade guide](https://laravel.com/docs/12.x/upgrade), before continuing here.
 
+### Upgrade to `ramsey/http-range` `v2.x` and `psr/http-message` `v2.x`
+
+Several HTTP related components and packages have been upgraded to use the latest version of
+[`ramsey/http-range`](https://github.com/ramsey/http-range) and thereby also
+[`psr/http-message` `v2.x`](https://github.com/php-fig/http-message).
+The [Streams](./streams/README.md) package is also affected by these changes.
+
+Mostly, the changes are concerned with method return types and method parameter types.
+For additional information, please review the changelog and eventually the source code of the mentioned packages.
+
 ### TOML parser changed to `devium/toml`
 
 The [configuration loader](./config/README.md) now requires [`devium/toml`](https://github.com/vanodevium/toml) for

--- a/docs/archive/v8x/redmine/README.md
+++ b/docs/archive/v8x/redmine/README.md
@@ -38,10 +38,12 @@ Issue::findOrFail(9874)
 
 ## Compatibility
 
-| Athenaeum Redmine Client | Redmine version |
-|--------------------------|-----------------|
-| `v6.x`                   | `>= v4.x`*      |
-| From `v5.19`             | `>= v4.x`*      |
+| Athenaeum Redmine Client | Redmine version            |
+|--------------------------|----------------------------|
+| From `v8.22`             | `v4.x`, `v5.0.x`, `v5.1.x` |
+| `v7.x`                   | `v4.x`                     |
+| `v6.x`                   | `v4.x`                     |
+| From `v5.19`             | `v4.x`                     |
 
 *:_This package might also work with newer versions of Redmine._
 


### PR DESCRIPTION
PR highlights support for Redmine v6.0.x API and the upgrade of the `ramsey/http-range` and `psr/http-messsage` dependencies, in the docs.
