### PR TITLE
Fix unset property check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Updated dependencies (_service update_).
 
+### Fixed
+
+* Unable to unset properties `$stream`, `$meta`, `$isReadable` and `$isWritable`, in `\Aedart\Streams\Stream::detach()`, due to possible hooks in a subclass (_phpstan error for PHP `v8.4`_). [#226](https://github.com/aedart/athenaeum/issues/226). 
+* Unable to unset property `$originalStream`, in `\Aedart\Streams\Transactions\Drivers\BaseTransactionDriver::close()`, due to possible hooks in a subclass (_phpstan error for PHP `v8.4`_). [#226](https://github.com/aedart/athenaeum/issues/226). 
+* Unable to unset property `$name`, in `\Aedart\Tests\Helpers\Dummies\Properties\Accessibility\Person::unsetName()`, due to possible hooks in a subclass (_phpstan error for PHP `v8.4`_). [#226](https://github.com/aedart/athenaeum/issues/226). 
+* Unable to unset property `$name`, in `\Aedart\Tests\Unit\Properties\OverloadTest::canUnsetProperty()`, due to possible hooks in a subclass (_phpstan error for PHP `v8.4`_). [#226](https://github.com/aedart/athenaeum/issues/226). 
+
 ## [9.1.0] - 2025-03-06
 
 ### Changed

--- a/packages/Streams/src/Stream.php
+++ b/packages/Streams/src/Stream.php
@@ -49,7 +49,7 @@ class Stream implements StreamInterface
     /**
      * The actual resource stream
      *
-     * @var resource
+     * @var resource|null
      */
     protected $stream;
 
@@ -169,12 +169,12 @@ class Stream implements StreamInterface
         }
 
         $resource = $this->stream;
-        unset(
-            $this->stream,
-            $this->meta,
-            $this->isReadable,
-            $this->isWritable
-        );
+
+        // Reset properties.
+        $this->stream = null;
+        $this->setMetaRepository();
+        $this->isReadable = null;
+        $this->isWritable = null;
 
         return $resource;
     }

--- a/tests/Helpers/Dummies/Properties/Accessibility/Person.php
+++ b/tests/Helpers/Dummies/Properties/Accessibility/Person.php
@@ -19,23 +19,23 @@ class Person
     /**
      * Name of person
      *
-     * @var string
+     * @var string|null
      */
-    public string $name = 'John Doe';
+    public string|null $name = 'John Doe';
 
     /**
      * Age of person
      *
-     * @var int
+     * @var int|null
      */
-    protected int $age = 42;
+    protected int|null $age = 42;
 
     /**
      * Height of person
      *
-     * @var int
+     * @var int|null
      */
-    private int $height = 193;
+    private int|null $height = 193;
 
     /**
      * N/A
@@ -90,8 +90,8 @@ class Person
     /**
      * Unset this person's name
      */
-    public function unsetName()
+    public function unsetName(): void
     {
-        unset($this->name);
+        $this->name = null;
     }
 }

--- a/tests/Unit/Properties/OverloadTest.php
+++ b/tests/Unit/Properties/OverloadTest.php
@@ -129,7 +129,13 @@ class OverloadTest extends PropertiesTestCase
     public function canUnsetProperty()
     {
         $dummy = $this->makeDummy();
-        unset($dummy->name);
+
+        // NOTE: unset($dummy->name) can yield an error from PHP v8.4, due to possible property hook in
+        // subclass. Therefore, here we simply set the property to null.
+        // unset($dummy->name);
+
+        $dummy->name = null;
+
         $this->assertFalse($dummy->isPropSet('name'));
     }
 


### PR DESCRIPTION
PR fixes PHPStan error, in which a class property cannot be unset due to possible property hook in subclass, in PHP `v8.4`.

## Details

All the affected properties are now reset, e.g. set to `null` or other appropriate default value.

## References

#226 
