### PR TITLE
Use native Deprecated attribute

### DIFF
--- a/packages/Audit/src/Concerns/ChangeRecording.php
+++ b/packages/Audit/src/Concerns/ChangeRecording.php
@@ -153,6 +153,7 @@ trait ChangeRecording
      *
      * @deprecated Since v10.x, use {@see auditTrailRecordFormatter()} instead
      */
+    #[\Deprecated(message: "use auditTrailRecordFormatter() instead", since: "10.x")]
     public function originalData(string $type): array|null
     {
         if ($this->shouldOmitDataFor($type)) {
@@ -178,6 +179,7 @@ trait ChangeRecording
      *
      * @deprecated Since v10.x, use {@see auditTrailRecordFormatter()} instead
      */
+    #[\Deprecated(message: "use auditTrailRecordFormatter() instead", since: "10.x")]
     public function formatOriginalData(array|null $filtered, string $type): array|null
     {
         return $filtered;
@@ -193,6 +195,7 @@ trait ChangeRecording
      *
      * @deprecated Since v10.x, use {@see auditTrailRecordFormatter()} instead
      */
+    #[\Deprecated(message: "use auditTrailRecordFormatter() instead", since: "10.x")]
     public function changedData(string $type): array|null
     {
         if ($this->shouldOmitDataFor($type)) {
@@ -224,6 +227,7 @@ trait ChangeRecording
      *
      * @deprecated Since v10.x, use {@see auditTrailRecordFormatter()} instead
      */
+    #[\Deprecated(message: "use auditTrailRecordFormatter() instead", since: "10.x")]
     public function formatChangedData(array|null $filtered, string $type): array|null
     {
         return $filtered;
@@ -244,6 +248,7 @@ trait ChangeRecording
      *
      * @deprecated Since v10.x, use {@see auditTrailRecordFormatter()} instead
      */
+    #[\Deprecated(message: "use auditTrailRecordFormatter() instead", since: "10.x")]
     public function filterAuditData(array|null $attributes = null): array|null
     {
         if (empty($attributes)) {
@@ -269,6 +274,7 @@ trait ChangeRecording
      *
      * @deprecated Since v10.x, use {@see auditTrailRecordFormatter()} instead
      */
+    #[\Deprecated(message: "use auditTrailRecordFormatter() instead", since: "10.x")]
     public function getHiddenForAudit(): array
     {
         if (!isset($this->hiddenInAuditTrail)) {
@@ -289,6 +295,7 @@ trait ChangeRecording
      *
      * @deprecated Since v10.x, use {@see auditTrailRecordFormatter()} instead
      */
+    #[\Deprecated(message: "use auditTrailRecordFormatter() instead", since: "10.x")]
     public function makeHiddenForAudit(array|string|null $attributes): static
     {
         $attributes = is_array($attributes)
@@ -313,6 +320,7 @@ trait ChangeRecording
      *
      * @deprecated Since v10.x, use {@see auditTrailRecordFormatter()} instead
      */
+    #[\Deprecated(message: "use auditTrailRecordFormatter() instead", since: "10.x")]
     public function attributesToHideForAudit(): array
     {
         // Use this method to hide attributes from Audit Trail entry
@@ -326,6 +334,7 @@ trait ChangeRecording
      *
      * @deprecated Since v10.x, use {@see auditTrailRecordFormatter()} instead
      */
+    #[\Deprecated(message: "use auditTrailRecordFormatter() instead", since: "10.x")]
     public function auditTimestampAttributes(): array
     {
         $attributes = [
@@ -350,6 +359,7 @@ trait ChangeRecording
      *
      * @deprecated Since v10.x, use {@see auditTrailRecordFormatter()} instead
      */
+    #[\Deprecated(message: "use auditTrailRecordFormatter() instead", since: "10.x")]
     public function shouldOmitDataFor(string $type): bool
     {
         $skipOn = [
@@ -379,6 +389,7 @@ trait ChangeRecording
      *
      * @deprecated Since v10.x, use {@see auditTrailRecordFormatter()} to customise audit trail message
      */
+    #[\Deprecated(message: "use auditTrailRecordFormatter() instead", since: "10.x")]
     public function getAuditTrailMessage(string $type): string|null
     {
         return null;

--- a/packages/Audit/src/Observers/Concerns/ModelAttributes.php
+++ b/packages/Audit/src/Observers/Concerns/ModelAttributes.php
@@ -31,8 +31,8 @@ trait ModelAttributes
      * @throws Throwable
      *
      * @deprecated Since v10.x, Will be removed in next major version.
-     *
      */
+    #[\Deprecated(message: "ModelAttributes trait will be removed in next major version. Use \Aedart\Audit\Formatters\DefaultRecordFormatter instead.", since: "10.x")]
     protected function resolveOriginalData(Model $model, string $type): mixed
     {
         return Invoker::invoke([$model, 'originalData'])
@@ -54,8 +54,8 @@ trait ModelAttributes
      * @throws Throwable
      *
      * @deprecated Since v10.x, Will be removed in next major version.
-     *
      */
+    #[\Deprecated(message: "ModelAttributes trait will be removed in next major version. Use \Aedart\Audit\Formatters\DefaultRecordFormatter instead.", since: "10.x")]
     protected function resolveChangedData(Model $model, string $type): mixed
     {
         return Invoker::invoke([$model, 'changedData'])
@@ -76,6 +76,7 @@ trait ModelAttributes
      *
      * @deprecated Since v10.x, Will be removed in next major version.
      */
+    #[\Deprecated(message: "ModelAttributes trait will be removed in next major version. Use \Aedart\Audit\Formatters\DefaultRecordFormatter instead.", since: "10.x")]
     protected function reduceOriginal(array|null $original, array|null $changed): array|null
     {
         if (!empty($original) && !empty($changed)) {
@@ -95,6 +96,7 @@ trait ModelAttributes
      *
      * @deprecated Since v10.x, Will be removed in next major version.
      */
+    #[\Deprecated(message: "ModelAttributes trait will be removed in next major version. Use \Aedart\Audit\Formatters\DefaultRecordFormatter instead.", since: "10.x")]
     protected function resolveAuditTrailMessage(Model $model, string $type): string|null
     {
         // Resolve message from "callback", when one exists
@@ -121,6 +123,7 @@ trait ModelAttributes
      *
      * @deprecated Since v10.x, Will be removed in next major version.
      */
+    #[\Deprecated(message: "ModelAttributes trait will be removed in next major version. Use \Aedart\Audit\Formatters\DefaultRecordFormatter instead.", since: "10.x")]
     protected function pluck(array $keys, array $target): array
     {
         return collect($target)


### PR DESCRIPTION
PR applies PHP's new [`#[\Deprecated]`](https://www.php.net/manual/en/class.deprecated.php) where it is possible. The `@deprecated` PHPDoc annotation is still used.

## References

* #236 
* #244  
