### PR TITLE
Fix remove response payload middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Added support for Psr `Response` in `RemovesResponsePayload` (_Http Api package_). [#274](https://github.com/aedart/athenaeum/issues/274).
+* Added support for outputting Psr `Response` in `\Aedart\Testing\Helpers\Http\Response`.
+
+### Fixed
+
+* Unable to use Psr `Response` in `RemovesResponsePayload` Http Middleware (_Http Api package_). [#274](https://github.com/aedart/athenaeum/issues/274).
+
 ## [10.1.0] - 2026-04-08
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,8 @@
         "roave/security-advisories": "dev-master",
         "symfony/var-dumper": "^v8.0.8",
         "symfony/yaml": "^v8.0.8",
+        "symfony/psr-http-message-bridge": "^v8.0.8",
+        "nyholm/psr7": "^1.8.2",
         "twig/twig": "^3.24.0"
     },
     "autoload": {

--- a/packages/Http/Api/composer.json
+++ b/packages/Http/Api/composer.json
@@ -22,6 +22,7 @@
         "aedart/athenaeum-etags": "^10.2",
         "aedart/athenaeum-support": "^10.2",
         "aedart/athenaeum-validation": "^10.2",
+        "aedart/athenaeum-streams": "^10.2",
         "illuminate/http": "^v13.3.0",
         "shrikeh/teapot": "^3.0.0"
     },

--- a/packages/Http/Api/src/Middleware/RemoveResponsePayload.php
+++ b/packages/Http/Api/src/Middleware/RemoveResponsePayload.php
@@ -2,10 +2,13 @@
 
 namespace Aedart\Http\Api\Middleware;
 
+use Aedart\Contracts\Streams\Exceptions\StreamException;
+use Aedart\Streams\FileStream;
 use Closure;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Teapot\StatusCode\All as Status;
 
 /**
@@ -36,26 +39,47 @@ class RemoveResponsePayload
      *
      * Note: If the response is not successful, then it will not be converted.
      *
-     * @param Request $request
-     * @param Closure $next
-     * @param string $key [optional] Query parameter that must trigger this middleware.
+     * @param  Request  $request
+     * @param  Closure  $next
+     * @param  string  $key  [optional] Query parameter that must trigger this middleware.
      *
-     * @return JsonResponse|Response
+     * @return mixed
+     *
+     * @throws StreamException
      */
-    public function handle(Request $request, Closure $next, string $key = 'no_payload'): JsonResponse|Response
+    public function handle(Request $request, Closure $next, string $key = 'no_payload'): mixed
     {
-        /** @var Response|JsonResponse $response */
+        /** @var Response|SymfonyResponse|ResponseInterface|null $response */
         $response = $next($request);
 
-        if ($response->isSuccessful()
-            && $request->has($key)
-            && in_array($request->query($key, false), static::$values)
-        ) {
+        // When no response available,...
+        if (!isset($response)) {
+            return $response;
+        }
+
+        // Early exit if "no payload" wasn't requested.
+        $noPayloadRequested = $request->has($key) && in_array($request->query($key, false), static::$values);
+        if (!$noPayloadRequested) {
+            return $response;
+        }
+
+        if ($response instanceof SymfonyResponse && $response->isSuccessful()) {
             return $response
                 ->setStatusCode(Status::NO_CONTENT)
                 ->setContent(null);
         }
 
+        if ($response instanceof ResponseInterface && $response->getStatusCode() >= Status::OK && $response->getStatusCode() < Status::MULTIPLE_OPTIONS) {
+            $nullStream = FileStream::openMemory()
+                ->append('')
+                ->positionToStart();
+
+            return $response
+                ->withStatus(Status::NO_CONTENT)
+                ->withBody($nullStream);
+        }
+
+        // Fall through, if not request was not successful or of unknown kind.
         return $response;
     }
 }

--- a/packages/Testing/src/Helpers/Http/Response.php
+++ b/packages/Testing/src/Helpers/Http/Response.php
@@ -5,6 +5,8 @@ namespace Aedart\Testing\Helpers\Http;
 use Aedart\Testing\Helpers\ConsoleDebugger;
 use Aedart\Utils\Json;
 use JsonException;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 /**
@@ -37,11 +39,31 @@ class Response
         }
 
         if ($debug) {
-            ConsoleDebugger::output([
-                'status' => $jsonResponse->getStatusCode() . ' ' . $jsonResponse->statusText(),
-                'headers' => $jsonResponse->headers->all(),
-                'body' => $content
-            ]);
+            if ($jsonResponse instanceof SymfonyResponse) {
+                $content = $jsonResponse->getContent();
+
+                ConsoleDebugger::output([
+                    'status' => $jsonResponse->getStatusCode() . ' ' . $jsonResponse->statusText(),
+                    'headers' => $jsonResponse->headers->all(),
+                    'body' => !empty($content)
+                        ? Json::decode($content, true)
+                        : null,
+                ]);
+            } elseif ($jsonResponse instanceof ResponseInterface) {
+                $content = $jsonResponse->getBody()->getContents();
+
+                ConsoleDebugger::output([
+                    'status' => $jsonResponse->getStatusCode() . ' ' . $jsonResponse->getReasonPhrase(),
+                    'headers' => $jsonResponse->getHeaders(),
+                    'body' => !empty($content)
+                        ? Json::decode($content, true)
+                        : null,
+                ]);
+
+                $jsonResponse->getBody()->rewind();
+            }
+
+            // Otherwise, do nothing in this case...
         }
 
         return $content;

--- a/tests/Integration/Http/Api/Middleware/RemoveResponsePayloadMiddlewareTest.php
+++ b/tests/Integration/Http/Api/Middleware/RemoveResponsePayloadMiddlewareTest.php
@@ -3,9 +3,12 @@
 namespace Aedart\Tests\Integration\Http\Api\Middleware;
 
 use Aedart\Http\Api\Middleware\RemoveResponsePayload;
+use Aedart\Streams\FileStream;
 use Aedart\Testing\Helpers\Http\Response;
 use Aedart\Tests\TestCases\Http\ApiResourcesTestCase;
+use Aedart\Utils\Json;
 use Codeception\Attribute\Group;
+use GuzzleHttp\Psr7\HttpFactory;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use JsonException;
@@ -65,6 +68,47 @@ class RemoveResponsePayloadMiddlewareTest extends ApiResourcesTestCase
      * @throws JsonException
      */
     #[Test]
+    public function convertsPsrResponseToNoContent(): void
+    {
+        $key = 'nrp';
+        Route::patch('/games/{id}', function (Request $request) {
+            $factory = new HttpFactory();
+            $body = FileStream::openTemporary()
+                ->append(Json::encode([
+                    'name' => $request->get('name', 'N/A')
+                ]))
+                ->positionToStart();
+
+            return $factory->createResponse(Status::OK)
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($body);
+        })
+            ->name('games.show')
+            ->middleware([
+                RemoveResponsePayload::class . ':' . $key
+            ]);
+
+        // Refresh name lookup or test could fail...
+        Route::getRoutes()->refreshNameLookups();
+
+        // ------------------------------------------------------------------ //
+
+        $url = route('games.show', 42) . '?' . $key . '=1';
+        $response = $this
+            ->patchJson($url, [
+                'name' => 'Sine Gordon'
+            ])
+            ->assertNoContent();
+
+        Response::decode($response);
+    }
+
+    /**
+     * @return void
+     *
+     * @throws JsonException
+     */
+    #[Test]
     public function doesNotConvertWhenResponseIsNotSuccessful(): void
     {
         $key = 'nrp';
@@ -72,6 +116,47 @@ class RemoveResponsePayloadMiddlewareTest extends ApiResourcesTestCase
             return response()->json([
                 'error' => 'some error'
             ], Status::UNPROCESSABLE_ENTITY);
+        })
+            ->name('games.show')
+            ->middleware([
+                RemoveResponsePayload::class . ':' . $key
+            ]);
+
+        // Refresh name lookup or test could fail...
+        Route::getRoutes()->refreshNameLookups();
+
+        // ------------------------------------------------------------------ //
+
+        $url = route('games.show', 42) . '?' . $key . '=1';
+        $response = $this
+            ->patchJson($url, [
+                'name' => 'Sine Gordon'
+            ])
+            ->assertUnprocessable();
+
+        Response::decode($response);
+    }
+
+    /**
+     * @return void
+     *
+     * @throws JsonException
+     */
+    #[Test]
+    public function doesNotConvertWhenPsrResponseIsNotSuccessful(): void
+    {
+        $key = 'nrp';
+        Route::patch('/games/{id}', function (Request $request) {
+            $factory = new HttpFactory();
+            $body = FileStream::openTemporary()
+                ->append(Json::encode([
+                    'error' => 'some error'
+                ]))
+                ->positionToStart();
+
+            return $factory->createResponse(Status::UNPROCESSABLE_ENTITY)
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($body);
         })
             ->name('games.show')
             ->middleware([


### PR DESCRIPTION
PR fixes issue where Psr Response cannot be returned by the `RemoveResponsePayload` Http Middleware.

## Details

Changed the return type to `mixed`, instead of the previous `JsonResponse|Response`. Also, added explicit support for dealing with response that implements the Psr `ResponseInterface`.

The `\Aedart\Testing\Helpers\Http\Response::decode` has also been enhanced to support outputting response Psr `Response`.

## References

* #274 
