### PR TITLE
Add audit trail formatter resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Refactored `EventData` concern to make use of new `Resolver` util (_Audit package_). [#276](https://github.com/aedart/athenaeum/issues/276).
-* `AuditTrailServiceProvider` now binds the `LegacyRecordFormatter` as the default formatter, which is returned by `Resolver::makeDefaultFormatter`(_Audit package_). [#276](https://github.com/aedart/athenaeum/issues/276).
+* `AuditTrailServiceProvider` now binds the `LegacyRecordFormatter` as the default formatter, which is returned by `Resolver::makeDefaultFormatter`(_Audit package_). [#276](https://github.com/aedart/athenaeum/issues/276), [#245](https://github.com/aedart/athenaeum/issues/245).
 
 ## [10.2.0] - 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* `Resolver` util that allows resolving an audit trail record `Formatter` for a given model (_Audit package_). [#276](https://github.com/aedart/athenaeum/issues/276).
+
+### Changed
+
+* Refactored `EventData` concern to make use of new `Resolver` util (_Audit package_). [#276](https://github.com/aedart/athenaeum/issues/276).
+* `AuditTrailServiceProvider` now binds the `LegacyRecordFormatter` as the default formatter, which is returned by `Resolver::makeDefaultFormatter`(_Audit package_). [#276](https://github.com/aedart/athenaeum/issues/276).
+
 ## [10.2.0] - 2026-04-13
 
 ### Changed

--- a/packages/Audit/src/Events/Concerns/EventData.php
+++ b/packages/Audit/src/Events/Concerns/EventData.php
@@ -2,7 +2,7 @@
 
 namespace Aedart\Audit\Events\Concerns;
 
-use Aedart\Audit\Formatters\LegacyRecordFormatter;
+use Aedart\Audit\Formatters\Resolver;
 use Aedart\Audit\Observers\Concerns\ModelAttributes;
 use Aedart\Contracts\Audit\Formatter;
 use Aedart\Contracts\Audit\Types;
@@ -11,7 +11,6 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Support\Carbon;
-use LogicException;
 
 /**
  * Concerns Event Data for audit trail
@@ -114,9 +113,7 @@ trait EventData
      */
     public function makeDefaultAuditTrailFormatter(Model $model): Formatter
     {
-        // TODO: Replace Legacy Record Formatter with "DefaultRecordFormatter"
-        // TODO: @see https://github.com/aedart/athenaeum/issues/245
-        return new LegacyRecordFormatter($model);
+        return Resolver::makeDefaultFormatter($model);
     }
 
     /**
@@ -233,17 +230,6 @@ trait EventData
      */
     protected function resolveRecordFormatter(Model $model): Formatter
     {
-        $formatter = match (true) {
-            method_exists($model, 'auditTrailRecordFormatter') => $model->auditTrailRecordFormatter(),
-            default => $this->makeDefaultAuditTrailFormatter($model),
-        };
-
-        return match (true) {
-            $formatter instanceof Formatter => $formatter,
-            is_null($formatter) => $this->makeDefaultAuditTrailFormatter($model),
-            is_string($formatter) && class_exists($formatter) => new $formatter($model),
-            is_string($formatter) && !class_exists($formatter) => throw new LogicException(sprintf('Invalid Audit Trail Formatter class path "%s", for model %s', $formatter, $model::class)),
-            default => throw new LogicException(sprintf('Unable to resolve Audit Trail Record Formatter for model %s', $model::class))
-        };
+        return Resolver::resolve($model);
     }
 }

--- a/packages/Audit/src/Formatters/Resolver.php
+++ b/packages/Audit/src/Formatters/Resolver.php
@@ -3,6 +3,7 @@
 namespace Aedart\Audit\Formatters;
 
 use Aedart\Contracts\Audit\Formatter;
+use Aedart\Support\Facades\IoCFacade;
 use Illuminate\Database\Eloquent\Model;
 use LogicException;
 
@@ -46,8 +47,6 @@ class Resolver
      */
     public static function makeDefaultFormatter(Model $model): Formatter
     {
-        // TODO: Replace Legacy Record Formatter with "DefaultRecordFormatter"
-        // TODO: @see https://github.com/aedart/athenaeum/issues/245
-        return new LegacyRecordFormatter($model);
+        return IoCFacade::make(Formatter::class, compact('model'));
     }
 }

--- a/packages/Audit/src/Formatters/Resolver.php
+++ b/packages/Audit/src/Formatters/Resolver.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Aedart\Audit\Formatters;
+
+use Aedart\Contracts\Audit\Formatter;
+use Illuminate\Database\Eloquent\Model;
+use LogicException;
+
+/**
+ * Audit Trail Record Formatter Resolver
+ *
+ * @author Alin Eugen Deac <aedart@gmail.com>
+ * @package Aedart\Audit\Formatters
+ */
+class Resolver
+{
+    /**
+     * Resolves an Audit Trail Record Formatter for the given model
+     *
+     * @param  Model  $model
+     *
+     * @return Formatter
+     */
+    public static function resolve(Model $model): Formatter
+    {
+        $formatter = match (true) {
+            method_exists($model, 'auditTrailRecordFormatter') => $model->auditTrailRecordFormatter(),
+            default => static::makeDefaultFormatter($model),
+        };
+
+        return match (true) {
+            $formatter instanceof Formatter => $formatter,
+            is_null($formatter) => static::makeDefaultFormatter($model),
+            is_string($formatter) && class_exists($formatter) => new $formatter($model),
+            is_string($formatter) && !class_exists($formatter) => throw new LogicException(sprintf('Invalid Audit Trail Formatter class path "%s", for model %s', $formatter, $model::class)),
+            default => throw new LogicException(sprintf('Unable to resolve Audit Trail Record Formatter for model %s', $model::class))
+        };
+    }
+
+    /**
+     * Returns a default audit trail record formatter
+     *
+     * @param  Model  $model
+     *
+     * @return Formatter
+     */
+    public static function makeDefaultFormatter(Model $model): Formatter
+    {
+        // TODO: Replace Legacy Record Formatter with "DefaultRecordFormatter"
+        // TODO: @see https://github.com/aedart/athenaeum/issues/245
+        return new LegacyRecordFormatter($model);
+    }
+}

--- a/packages/Audit/src/Providers/AuditTrailServiceProvider.php
+++ b/packages/Audit/src/Providers/AuditTrailServiceProvider.php
@@ -2,9 +2,11 @@
 
 namespace Aedart\Audit\Providers;
 
+use Aedart\Audit\Formatters\LegacyRecordFormatter;
 use Aedart\Audit\Helpers\Reason;
 use Aedart\Audit\Subscribers\AuditTrailEventSubscriber;
 use Aedart\Contracts\Audit\CallbackReason;
+use Aedart\Contracts\Audit\Formatter;
 use Aedart\Support\Helpers\Config\ConfigTrait;
 use Aedart\Support\Helpers\Events\DispatcherTrait;
 use Illuminate\Support\ServiceProvider;
@@ -23,6 +25,21 @@ class AuditTrailServiceProvider extends ServiceProvider
     public array $singletons = [
         CallbackReason::class => Reason::class
     ];
+
+    /**
+     * @inheritdoc
+     */
+    public function register(): void
+    {
+        $this->app->bind(Formatter::class, function ($app, array $arguments) {
+            /** @var \Illuminate\Database\Eloquent\Model $model */
+            $model = $arguments['model'] ?? null;
+
+            // TODO: Replace Legacy Record Formatter with "DefaultRecordFormatter"
+            // TODO: @see https://github.com/aedart/athenaeum/issues/245
+            return new LegacyRecordFormatter($model);
+        });
+    }
 
     /**
      * Bootstrap this service


### PR DESCRIPTION
PR adds a `Resolver` that is responsible for resolving an audit trail record `Formatter` for a given Eloquent model. It no formatter is registered / provided by the model itself, it will default to the `LegacyRecordFormatter`.

## Details

The default (_or fallback_) `Formatter` is resolved from the Service Container. This should allow developers to override the binding, in case such is desired.

## References

* #276 
* #245
